### PR TITLE
TEST: Add test for API end point auth

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,7 @@ replica:
 
 test:
   adapter: postgresql
-  database: doubtfire_dev
+  database: doubtfire_dev_test
   username: itig
   password: d872$dh
   host: localhost

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -28,11 +28,11 @@ class AuthTest < MiniTest::Test
     expected_auth = User.first
 
     # Check to see if the username matches what was expected
-    assert_equal actual_auth['user']['username'], User.first.username
+    assert_equal actual_auth['user']['username'], expected_auth.username
     # Check to see if the first name matches what was expected
-    assert_equal actual_auth['user']['first_name'], User.first.first_name
+    assert_equal actual_auth['user']['first_name'], expected_auth.first_name
     # Check to see if the last name matches what was expected
-    assert_equal actual_auth['user']['last_name'], User.first.last_name
+    assert_equal actual_auth['user']['last_name'], expected_auth.last_name
   end
   # End POST tests
   # --------------------------------------------------------------------------- #

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -2,13 +2,10 @@ require 'test_helper'
 
 class AuthTest < MiniTest::Test
   include Rack::Test::Methods
+  include AuthHelper
 
   def app
     Rails.application
-  end
-
-  def setup
-    @auth_token = JSON.parse((post '/api/auth.json', '{"username":"acain", "password":"password"}', "CONTENT_TYPE" => 'application/json').body)['auth_token']
   end
 
   # --------------------------------------------------------------------------- #
@@ -21,24 +18,21 @@ class AuthTest < MiniTest::Test
 
   # Test POST for new authentication token
   def test_auth_post
+    data_to_post = add_auth_token({
+        username: "acain",
+        password: "password"
+    })
     # Get response back for logging in with username 'acain' password 'password'
-    post  '/api/auth.json',
-          '{'                       +
-            '"username":"acain",'   +
-            '"password":"password"' +
-          '}',
-          "CONTENT_TYPE" => 'application/json'
+    post  '/api/auth.json', data_to_post.to_json, "CONTENT_TYPE" => 'application/json'
+    actual_auth = JSON.parse(last_response.body)
+    expected_auth = User.first
 
     # Check to see if the username matches what was expected
-    assert_equal 'acain', JSON.parse(last_response.body)['user']['username']
+    assert_equal actual_auth['user']['username'], User.first.username
     # Check to see if the first name matches what was expected
-    assert_equal 'Andrew', JSON.parse(last_response.body)['user']['first_name']
-    # Check to see if first name is written in Pascal Case
-    refute_equal 'andrew', JSON.parse(last_response.body)['user']['first_name']
+    assert_equal actual_auth['user']['first_name'], User.first.first_name
     # Check to see if the last name matches what was expected
-    assert_equal 'Cain', JSON.parse(last_response.body)['user']['last_name']
-    # Check to see if last name is written in Pascal Case
-    refute_equal 'cain', JSON.parse(last_response.body)['user']['last_name']
+    assert_equal actual_auth['user']['last_name'], User.first.last_name
   end
   # End POST tests
   # --------------------------------------------------------------------------- #
@@ -48,14 +42,17 @@ class AuthTest < MiniTest::Test
 
   # Test put for authentication token
   def test_auth_put
-    put "/api/auth/#{@auth_token}.json",
-        '{'                     +
-          '"username":"acain"'  +
-        '}',
-        "CONTENT_TYPE" => 'application/json'
+    auth_token = get_auth_token
+    data_to_put = {
+        username: "acain",
+        password: "password"
+    }
+    put "/api/auth/#{auth_token}.json", data_to_put.to_json, "CONTENT_TYPE" => 'application/json'
+    actual_auth = JSON.parse(last_response.body)['auth_token']
+    expected_auth = User.first.auth_token
 
     # Check to see if the response auth token matches the auth token that was sent through in put
-    assert_equal @auth_token, JSON.parse(last_response.body)['auth_token']
+    assert_equal actual_auth, expected_auth
   end
   # End PUT tests
   # --------------------------------------------------------------------------- #
@@ -65,8 +62,9 @@ class AuthTest < MiniTest::Test
 
   # Test for deleting authentication token
   def test_auth_delete
+    auth_token = get_auth_token
     # Get the auth token needed for delete test
-    delete "/api/auth/#{@auth_token}.json", "CONTENT_TYPE" => 'application/json'
+    delete "/api/auth/#{auth_token}.json", "CONTENT_TYPE" => 'application/json'
     # 200 response code means success!
     assert_equal last_response.status, 200
   end

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class AuthTest < MiniTest::Test
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+
+  def test_auth_post
+    # Get response back for logging in with username 'acain' password 'password'
+    post '/api/auth.json', '{"username":"acain", "password":"password"}', "CONTENT_TYPE" => 'application/json'
+    # Check to see if the username matches what was expected
+    assert JSON.parse(last_response.body)['user']['username'], 'acain'
+    # Check to see if the first name matches what was expected
+    assert JSON.parse(last_response.body)['user']['first_name'], 'andrew'
+    # Check to see if the last name matches what was expected
+    assert JSON.parse(last_response.body)['user']['last_name'], 'cain'
+  end
+
+  def test_auth_put
+    # Get the auth token needed for put test
+    auth_token = JSON.parse((post '/api/auth.json', '{"username":"acain", "password":"password"}', "CONTENT_TYPE" => 'application/json').body)['auth_token']
+    put "/api/auth/#{auth_token}.json", '{"username":"acain"}', "CONTENT_TYPE" => 'application/json'
+    # Check to see if the response auth token matches the auth token that was sent through in put
+    assert JSON.parse(last_response.body)['auth_token'], auth_token
+  end
+
+  def test_auth_delete
+    # Get the auth token needed for delete test
+    auth_token = JSON.parse((post '/api/auth.json', '{"username":"acain", "password":"password"}', "CONTENT_TYPE" => 'application/json').body)['auth_token']
+    delete "/api/auth/#{auth_token}.json", "CONTENT_TYPE" => 'application/json'
+    # 200 response code means success!
+    assert_equal(last_response.status, 200)
+  end
+end

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -16,7 +16,10 @@ class AuthTest < MiniTest::Test
   # ------- /api/auth.json
   # ------- POST PUT DELETE
 
-  # POST test
+  # --------------------------------------------------------------------------- #
+  # POST tests
+
+  # Test POST for new authentication token
   def test_auth_post
     # Get response back for logging in with username 'acain' password 'password'
     post  '/api/auth.json',
@@ -27,18 +30,23 @@ class AuthTest < MiniTest::Test
           "CONTENT_TYPE" => 'application/json'
 
     # Check to see if the username matches what was expected
-    assert_equal('acain', JSON.parse(last_response.body)['user']['username'])
+    assert_equal 'acain', JSON.parse(last_response.body)['user']['username']
     # Check to see if the first name matches what was expected
-    assert_equal('Andrew', JSON.parse(last_response.body)['user']['first_name'])
+    assert_equal 'Andrew', JSON.parse(last_response.body)['user']['first_name']
     # Check to see if first name is written in Pascal Case
-    refute_equal('andrew', JSON.parse(last_response.body)['user']['first_name'])
+    refute_equal 'andrew', JSON.parse(last_response.body)['user']['first_name']
     # Check to see if the last name matches what was expected
-    assert_equal('Cain', JSON.parse(last_response.body)['user']['last_name'])
+    assert_equal 'Cain', JSON.parse(last_response.body)['user']['last_name']
     # Check to see if last name is written in Pascal Case
-    refute_equal('cain', JSON.parse(last_response.body)['user']['last_name'])
+    refute_equal 'cain', JSON.parse(last_response.body)['user']['last_name']
   end
+  # End POST tests
+  # --------------------------------------------------------------------------- #
 
-  # PUT test
+  # --------------------------------------------------------------------------- #
+  # PUT tests
+
+  # Test put for authentication token
   def test_auth_put
     put "/api/auth/#{@auth_token}.json",
         '{'                     +
@@ -47,14 +55,21 @@ class AuthTest < MiniTest::Test
         "CONTENT_TYPE" => 'application/json'
 
     # Check to see if the response auth token matches the auth token that was sent through in put
-    assert_equal(@auth_token, JSON.parse(last_response.body)['auth_token'])
+    assert_equal @auth_token, JSON.parse(last_response.body)['auth_token']
   end
+  # End PUT tests
+  # --------------------------------------------------------------------------- #
 
-  # DELETE test
+  # --------------------------------------------------------------------------- #
+  # DELETE tests
+
+  # Test for deleting authentication token
   def test_auth_delete
     # Get the auth token needed for delete test
     delete "/api/auth/#{@auth_token}.json", "CONTENT_TYPE" => 'application/json'
     # 200 response code means success!
-    assert_equal(last_response.status, 200)
+    assert_equal last_response.status, 200
   end
+  # End DELETE tests
+  # --------------------------------------------------------------------------- #
 end

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -28,11 +28,11 @@ class AuthTest < MiniTest::Test
     expected_auth = User.first
 
     # Check to see if the username matches what was expected
-    assert_equal actual_auth['user']['username'], expected_auth.username
+    assert_equal expected_auth.username, actual_auth['user']['username']
     # Check to see if the first name matches what was expected
-    assert_equal actual_auth['user']['first_name'], expected_auth.first_name
+    assert_equal expected_auth.first_name, actual_auth['user']['first_name']
     # Check to see if the last name matches what was expected
-    assert_equal actual_auth['user']['last_name'], expected_auth.last_name
+    assert_equal expected_auth.last_name, actual_auth['user']['last_name']
   end
   # End POST tests
   # --------------------------------------------------------------------------- #
@@ -52,7 +52,7 @@ class AuthTest < MiniTest::Test
     expected_auth = User.first.auth_token
 
     # Check to see if the response auth token matches the auth token that was sent through in put
-    assert_equal actual_auth, expected_auth
+    assert_equal expected_auth, actual_auth
   end
   # End PUT tests
   # --------------------------------------------------------------------------- #
@@ -66,7 +66,7 @@ class AuthTest < MiniTest::Test
     # Get the auth token needed for delete test
     delete "/api/auth/#{auth_token}.json", "CONTENT_TYPE" => 'application/json'
     # 200 response code means success!
-    assert_equal last_response.status, 200
+    assert_equal 200, last_response.status 
   end
   # End DELETE tests
   # --------------------------------------------------------------------------- #

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -27,11 +27,15 @@ class AuthTest < MiniTest::Test
           "CONTENT_TYPE" => 'application/json'
 
     # Check to see if the username matches what was expected
-    assert JSON.parse(last_response.body)['user']['username'], 'acain'
+    assert_equal('acain', JSON.parse(last_response.body)['user']['username'])
     # Check to see if the first name matches what was expected
-    assert JSON.parse(last_response.body)['user']['first_name'], 'andrew'
+    assert_equal('Andrew', JSON.parse(last_response.body)['user']['first_name'])
+    # Check to see if first name is written in Pascal Case
+    refute_equal('andrew', JSON.parse(last_response.body)['user']['first_name'])
     # Check to see if the last name matches what was expected
-    assert JSON.parse(last_response.body)['user']['last_name'], 'cain'
+    assert_equal('Cain', JSON.parse(last_response.body)['user']['last_name'])
+    # Check to see if last name is written in Pascal Case
+    refute_equal('cain', JSON.parse(last_response.body)['user']['last_name'])
   end
 
   # PUT test
@@ -43,7 +47,7 @@ class AuthTest < MiniTest::Test
         "CONTENT_TYPE" => 'application/json'
 
     # Check to see if the response auth token matches the auth token that was sent through in put
-    assert JSON.parse(last_response.body)['auth_token'], @auth_token
+    assert_equal(@auth_token, JSON.parse(last_response.body)['auth_token'])
   end
 
   # DELETE test

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -19,11 +19,12 @@ class AuthTest < MiniTest::Test
   # POST test
   def test_auth_post
     # Get response back for logging in with username 'acain' password 'password'
-    post '/api/auth.json',
-                          '{'                       +
-                            '"username":"acain",'   +
-                            '"password":"password"' +
-                          '}', "CONTENT_TYPE" => 'application/json'
+    post  '/api/auth.json',
+          '{'                       +
+            '"username":"acain",'   +
+            '"password":"password"' +
+          '}',
+          "CONTENT_TYPE" => 'application/json'
 
     # Check to see if the username matches what was expected
     assert JSON.parse(last_response.body)['user']['username'], 'acain'
@@ -35,10 +36,11 @@ class AuthTest < MiniTest::Test
 
   # PUT test
   def test_auth_put
-    put "/api/auth/#{@auth_token}.json",
-                                        '{'                     +
-                                          '"username":"acain"'  +
-                                        '}', "CONTENT_TYPE" => 'application/json'
+    put '/api/auth/#{@auth_token}.json',
+        '{'                     +
+          '"username":"acain"'  +
+        '}',
+        "CONTENT_TYPE" => 'application/json'
 
     # Check to see if the response auth token matches the auth token that was sent through in put
     assert JSON.parse(last_response.body)['auth_token'], @auth_token

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -7,9 +7,24 @@ class AuthTest < MiniTest::Test
     Rails.application
   end
 
+  def setup
+    @auth_token = JSON.parse((post '/api/auth.json', '{"username":"acain", "password":"password"}', "CONTENT_TYPE" => 'application/json').body)['auth_token']
+  end
+
+  # --------------------------------------------------------------------------- #
+  # --- Endpoint testing for:
+  # ------- /api/auth.json
+  # ------- POST PUT DELETE
+
+  # POST test
   def test_auth_post
     # Get response back for logging in with username 'acain' password 'password'
-    post '/api/auth.json', '{"username":"acain", "password":"password"}', "CONTENT_TYPE" => 'application/json'
+    post '/api/auth.json',
+                          '{'                       +
+                            '"username":"acain",'   +
+                            '"password":"password"' +
+                          '}', "CONTENT_TYPE" => 'application/json'
+
     # Check to see if the username matches what was expected
     assert JSON.parse(last_response.body)['user']['username'], 'acain'
     # Check to see if the first name matches what was expected
@@ -18,18 +33,21 @@ class AuthTest < MiniTest::Test
     assert JSON.parse(last_response.body)['user']['last_name'], 'cain'
   end
 
+  # PUT test
   def test_auth_put
-    # Get the auth token needed for put test
-    auth_token = JSON.parse((post '/api/auth.json', '{"username":"acain", "password":"password"}', "CONTENT_TYPE" => 'application/json').body)['auth_token']
-    put "/api/auth/#{auth_token}.json", '{"username":"acain"}', "CONTENT_TYPE" => 'application/json'
+    put "/api/auth/#{@auth_token}.json",
+                                        '{'                     +
+                                          '"username":"acain"'  +
+                                        '}', "CONTENT_TYPE" => 'application/json'
+
     # Check to see if the response auth token matches the auth token that was sent through in put
-    assert JSON.parse(last_response.body)['auth_token'], auth_token
+    assert JSON.parse(last_response.body)['auth_token'], @auth_token
   end
 
+  # DELETE test
   def test_auth_delete
     # Get the auth token needed for delete test
-    auth_token = JSON.parse((post '/api/auth.json', '{"username":"acain", "password":"password"}', "CONTENT_TYPE" => 'application/json').body)['auth_token']
-    delete "/api/auth/#{auth_token}.json", "CONTENT_TYPE" => 'application/json'
+    delete "/api/auth/#{@auth_token}.json", "CONTENT_TYPE" => 'application/json'
     # 200 response code means success!
     assert_equal(last_response.status, 200)
   end

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -36,7 +36,7 @@ class AuthTest < MiniTest::Test
 
   # PUT test
   def test_auth_put
-    put '/api/auth/#{@auth_token}.json',
+    put "/api/auth/#{@auth_token}.json",
         '{'                     +
           '"username":"acain"'  +
         '}',

--- a/test/helpers/auth_helper.rb
+++ b/test/helpers/auth_helper.rb
@@ -1,0 +1,16 @@
+module AuthHelper
+
+  def get_auth_token
+    user = User.first
+    user.extend_authentication_token(true)
+    user.auth_token
+  end
+
+  def add_auth_token(hash)
+    hash[:auth_token] = get_auth_token
+    hash
+  end
+
+  module_function :get_auth_token
+  module_function :add_auth_token
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,9 @@ require 'database_cleaner'
 # Uncomment for awesome colorful output
 require "minitest/pride"
 
+# Require help with all tests
+require 'helpers/auth_helper'
+
 class ActiveSupport::TestCase
     ActiveRecord::Migration.check_pending!
 


### PR DESCRIPTION
This sees the inclusion of endpoint testing for `auth` for `post`, `put` and `delete`