### PR TITLE
Add ghostscript backup when validating a PDF

### DIFF
--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -342,10 +342,18 @@ module FileHelper
   def pdf_valid?(file)
     did_succeed = false
 
-    try_within 30, "validating PDF" do
+    try_within 30, "validating PDF using pdftk" do
       did_succeed = system "nice -n 10 pdftk #{file} output /dev/null dont_ask"
+    end
+
+    unless did_succeed
+      logger.warn "Failed to validate PDF file. Trying with ghostscript"
+      try_within 30, "validating PDF using ghostscript" do
+        did_succeed = system "nice -n 10 gs -o /dev/null -sDEVICE=nullpage -r36x36 -dNOPAUSE -q #{file} >>/dev/null 2>>/dev/null"
+      end
+
       unless did_succeed
-        logger.error "Failed to validate PDF file. Is pdftk installed?"
+        logger.error "Failed to validate pdf file. Is ghostscript installed?"
       end
     end
 


### PR DESCRIPTION
# Problem

Whenever PDFs are validated using pdftk (under OS X El Capitan) there seems to be some stalling issues where pdftk fails (refer to this [SO post](http://stackoverflow.com/questions/32505951/pdftk-server-on-os-x-10-11)).

E.g., under OS X 10.11 try:

```
$ pdftk some_pdf.pdf  output /dev/null dont_ask
```

It stalls for every El Capitan install using `pdftk 2.02`. Instead, the following [SO post](http://stackoverflow.com/a/3694338) shows how we can do this speedily using ghostscript:

```
$ gs -o /dev/null -sDEVICE=nullpage -r36x36 -dNOPAUSE -q some_pdf.pdf
```

# TL;DR

This PR adds ghostscript validation when pdftk fails. As an alternative to pdftk for validation, we could use ghostscript instead for development purposes, but depends on what you think RE this @macite...