### PR TITLE
Fix CSV download for task statistics

### DIFF
--- a/app/api/learning_alignment.rb
+++ b/app/api/learning_alignment.rb
@@ -46,7 +46,7 @@ module Api
       end
 
       if params[:project_id].nil?
-        if not authorise? current_user, unit, :download_csv
+        if not authorise? current_user, unit, :download_unit_csv
           error!({"error" => "Not authorised to download CSV of task alignment in #{unit.code}"}, 403)
         end
 

--- a/app/api/task_definitions.rb
+++ b/app/api/task_definitions.rb
@@ -169,8 +169,8 @@ module Api
     get '/csv/task_definitions' do
       unit = Unit.find(params[:unit_id])
 
-      if not authorise? current_user, unit, :download_csv
-        error!({"error" => "Not authorised to upload CSV of tasks"}, 403)
+      if not authorise? current_user, unit, :download_unit_csv
+        error!({"error" => "Not authorised to download CSV of tasks"}, 403)
       end
 
       content_type "application/octet-stream"

--- a/app/api/units.rb
+++ b/app/api/units.rb
@@ -207,7 +207,7 @@ module Api
     desc "Download CSV of all students in this unit"
     get '/csv/units/:id' do
       unit = Unit.find(params[:id])
-      if not authorise? current_user, unit, :download_csv
+      if not authorise? current_user, unit, :download_unit_csv
         error!({"error" => "Not authorised to download CSV of students enrolled in #{unit.code}"}, 403)
       end
 
@@ -220,7 +220,7 @@ module Api
     desc "Download CSV of all student tasks in this unit"
     get '/csv/units/:id/task_completion' do
       unit = Unit.find(params[:id])
-      if not authorise? current_user, unit, :download_csv
+      if not authorise? current_user, unit, :download_unit_csv
         error!({"error" => "Not authorised to download CSV of student tasks in #{unit.code}"}, 403)
       end
 

--- a/app/api/users.rb
+++ b/app/api/users.rb
@@ -202,8 +202,8 @@ module Api
 
     desc "Download CSV of all users"
     get '/csv/users' do
-      if not authorise? current_user, User, :download_csv
-        error!({"error" => "Not authorised to upload CSV of users"}, 403)
+      if not authorise? current_user, User, :download_system_csv
+        error!({"error" => "Not authorised to download CSV of all users"}, 403)
       end
 
       content_type "application/octet-stream"

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -22,7 +22,8 @@ class Unit < ActiveRecord::Base
       :get_students,
       :enrol_student,
       :provide_feedback,
-      :download_stats
+      :download_stats,
+      :download_unit_csv
     ]
 
     # What can convenors do with units?
@@ -31,7 +32,7 @@ class Unit < ActiveRecord::Base
       :get_students,
       :enrol_student,
       :upload_csv,
-      :download_csv,
+      :download_unit_csv,
       :update,
       :employ_staff,
       :add_tutorial,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -205,7 +205,8 @@ class User < ActiveRecord::Base
 
     # What can tutors do with users?
     tutor_role_permissions = [
-      :act_tutor
+      :act_tutor,
+      :download_csv
     ]
 
     # What can students do with users?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,7 +178,8 @@ class User < ActiveRecord::Base
       :create_user,
       :upload_csv,
       :list_users,
-      :download_csv,
+      :download_system_csv,
+      :download_unit_csv,
       :update_user,
       :create_unit,
       :act_tutor,
@@ -196,7 +197,7 @@ class User < ActiveRecord::Base
       :update_user,
       :demote_user,
       :upload_csv,
-      :download_csv,
+      :download_unit_csv,
       :create_unit,
       :act_tutor,
       :convene_units,
@@ -206,7 +207,7 @@ class User < ActiveRecord::Base
     # What can tutors do with users?
     tutor_role_permissions = [
       :act_tutor,
-      :download_csv
+      :download_unit_csv
     ]
 
     # What can students do with users?


### PR DESCRIPTION
Whilst trying to download CSV of task statistics as a tutor:

> `{"error":"Not authorised to download CSV of student tasks in COS10009-COS60006"}`

Convenors could only download CSV-related content about a unit. This is separated into a new permission, `:download_unit_csv`, for all content that can be downloaded about a unit (including download task statistics).

Administation content, such as downloading a list of all user is now separated into `:download_system_csv`, which is restricted to administrator system roles only.