### PR TITLE
Fix minitest framework and add additional helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,8 @@ group :development, :test, :replica do
   gem 'minitest-rails'
   gem 'minitest-hyper'
   gem 'database_cleaner'
-  gem "minitest-osx"
+  gem 'minitest-osx'
+  gem 'minitest-around'
 end
 
 # Student submission

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ group :production, :test, :replica do
 end
 
 group :development, :test, :replica do
-  gem 'rspec-rails', '~> 3'
   gem 'factory_girl_rails'
   gem 'minitest-rails'
   gem 'minitest-hyper'

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :production do
   gem 'passenger', '= 4.0.42'
 end
 
-group :production, :test, :replica do
+group :production, :replica do
   gem 'mysql2'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,6 @@ GEM
     devise_ldap_authenticatable (0.8.5)
       devise (>= 3.4.1)
       net-ldap (>= 0.6.0, <= 0.11)
-    diff-lcs (1.2.5)
     docile (1.1.5)
     encryptor (1.3.0)
     enumerable-lazy (0.0.1)
@@ -129,6 +128,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    minitest-around (0.3.2)
+      minitest (~> 5.0)
     minitest-hyper (0.2.0)
     minitest-osx (0.1.0)
       minitest (~> 5.4)
@@ -199,23 +200,6 @@ GEM
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rmagick (2.15.4)
-    rspec-core (3.4.4)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-rails (3.4.2)
-      actionpack (>= 3.0, < 4.3)
-      activesupport (>= 3.0, < 4.3)
-      railties (>= 3.0, < 4.3)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
     ruby-filemagic (0.7.1)
     ruby-progressbar (1.8.1)
     rubyzip (1.2.0)
@@ -273,6 +257,7 @@ DEPENDENCIES
   grape-swagger
   hirb
   launchy
+  minitest-around
   minitest-hyper
   minitest-osx
   minitest-rails
@@ -287,7 +272,6 @@ DEPENDENCIES
   rails_best_practices
   require_all (= 1.3.3)
   rmagick (~> 2.15)
-  rspec-rails (~> 3)
   ruby-filemagic
   rubyzip
   simplecov

--- a/lib/helpers/database_populator.rb
+++ b/lib/helpers/database_populator.rb
@@ -330,15 +330,16 @@ class DatabasePopulator
     # Define fixed user data here
     @user_data = {
       acain:              {first_name: "Andrew",  last_name: "Cain",          nickname: "Macite",         role_id: Role.admin_id },
-      cwoodward:          {first_name: "Clinton", last_name: "Woodward",      nickname: "The Giant",      role_id: Role.admin_id },
-      ajones:             {first_name: "Allan",   last_name: "Jones",         nickname: "P-Jiddy",        role_id: Role.convenor_id },
+      aconvenor:          {first_name: "Clinton", last_name: "Woodward",      nickname: "The Giant",      role_id: Role.convenor_id },
+      aadmin:             {first_name: "Allan",   last_name: "Jones",         nickname: "P-Jiddy",        role_id: Role.admin_id },
       rwilson:            {first_name: "Reuben",  last_name: "Wilson",        nickname: "Reubs",          role_id: Role.convenor_id },
-      akihironoguchi:     {first_name: "Akihiro", last_name: "Noguchi",       nickname: "Animations",     role_id: Role.tutor_id },
+      atutor:             {first_name: "Akihiro", last_name: "Noguchi",       nickname: "Animations",     role_id: Role.tutor_id },
       acummaudo:          {first_name: "Alex",    last_name: "Cummaudo",      nickname: "DoubtfireDude",  role_id: Role.convenor_id },
       cliff:              {first_name: "Cliff",   last_name: "Warren",        nickname: "Cliff",          role_id: Role.tutor_id },
       joostfunkekupper:   {first_name: "Joost",   last_name: "Funke Kupper",  nickname: "Joe",            role_id: Role.tutor_id },
       angusmorton:        {first_name: "Angus",   last_name: "Morton",        nickname: "Angus",          role_id: Role.tutor_id },
-      "123456X" =>        {first_name: "Fred",    last_name: "Jones",         nickname: "Foo",            role_id: Role.student_id }
+      "123456X" =>        {first_name: "Fred",    last_name: "Jones",         nickname: "Foo",            role_id: Role.student_id },
+      astudent:           {first_name: "student", last_name: "surname",       nickname: "Foo",            role_id: Role.student_id }
     }
     # Add 10 tutors to fixed info
     10.times do |count|
@@ -361,14 +362,14 @@ class DatabasePopulator
       intro_prog: {
         code: "COS10001",
         name: "Introduction to Programming",
-        convenors: [ :acain, :cwoodward ],
+        convenors: [ :acain, :aconvenor ],
         tutors: [
           { user: :acain, num: many_tutorials },
-          { user: :cwoodward, num: many_tutorials },
-          { user: :ajones, num: many_tutorials },
+          { user: :aconvenor, num: many_tutorials },
+          { user: :aadmin, num: many_tutorials },
           { user: :rwilson, num: many_tutorials },
           { user: :acummaudo, num: some_tutorials },
-          { user: :akihironoguchi, num: many_tutorials },
+          { user: :atutor, num: many_tutorials },
           { user: :joostfunkekupper, num: many_tutorials },
           { user: :angusmorton, num: some_tutorials },
           { user: :cliff, num: some_tutorials },
@@ -380,11 +381,11 @@ class DatabasePopulator
       oop: {
         code: "COS20007",
         name: "Object Oriented Programming",
-        convenors: [ :acain, :cwoodward, :ajones, :acummaudo ],
+        convenors: [ :acain, :aconvenor, :aadmin, :acummaudo ],
         tutors: [
           { user: "tutor_1", num: few_tutorials },
           { user: :angusmorton, num: few_tutorials },
-          { user: :akihironoguchi, num: few_tutorials },
+          { user: :atutor, num: few_tutorials },
           { user: :joostfunkekupper, num: few_tutorials },
         ],
         num_tasks: many_tasks,
@@ -394,9 +395,9 @@ class DatabasePopulator
       ai4g: {
         code: "COS30046",
         name: "Artificial Intelligence for Games",
-        convenors: [ :cwoodward ],
+        convenors: [ :aconvenor ],
         tutors: [
-          { user: :cwoodward, num: few_tutorials },
+          { user: :aconvenor, num: few_tutorials },
           { user: :cliff, num: few_tutorials },
         ],
         num_tasks: few_tasks,
@@ -406,13 +407,13 @@ class DatabasePopulator
       gameprog: {
         code: "COS30243",
         name: "Game Programming",
-        convenors: [ :cwoodward, :acummaudo ],
+        convenors: [ :aconvenor, :acummaudo ],
         tutors: [
-          { user: :cwoodward, num: few_tutorials },
+          { user: :aconvenor, num: few_tutorials },
         ],
         num_tasks: few_tasks,
         ilos: rand(0..3),
-        students: [ :acain, :ajones ]
+        students: [ :acain, :aadmin ]
       },
     }
     puts "-> Defined #{@user_data.length} fixed users and #{@unit_data.length} units"

--- a/lib/helpers/randomizer.rb
+++ b/lib/helpers/randomizer.rb
@@ -12,7 +12,14 @@ class Randomizer
   # Randomly returns a new task for the given project
   #
   def self.random_task_for_project(project)
-    task_def = project.unit.task_definitions.sample
+    task_def = self.random_task_def_for_project(project)
     project.task_for_task_definition(task_def)
+  end
+
+  #
+  # Randomly returns a new task definition for the given project
+  #
+  def self.random_task_def_for_project(project)
+    project.unit.task_definitions.sample
   end
 end

--- a/lib/tasks/test_setup.rake
+++ b/lib/tasks/test_setup.rake
@@ -6,7 +6,6 @@ namespace :test do
   task setup: [:environment, 'db:setup', 'db:migrate'] do
     require 'helpers/database_populator'
     dbpop = DatabasePopulator.new
-    dbpop.generate_user_roles()
     dbpop.generate_users()
     dbpop.generate_units()
   end

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -116,7 +116,6 @@ class AuthTest < ActiveSupport::TestCase
 
   # Test put for authentication token
   def test_auth_put
-    auth_token = get_auth_token
     data_to_put = {
         username: "acain",
         password: "password"
@@ -136,7 +135,6 @@ class AuthTest < ActiveSupport::TestCase
 
   # Test for deleting authentication token
   def test_auth_delete
-    auth_token = get_auth_token
     # Get the auth token needed for delete test
     delete "/api/auth/#{auth_token}.json", "CONTENT_TYPE" => 'application/json'
     # 200 response code means success!

--- a/test/api/auth_test.rb
+++ b/test/api/auth_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class AuthTest < MiniTest::Test
+class AuthTest < ActiveSupport::TestCase
   include Rack::Test::Methods
   include TestHelpers::AuthHelper
   include TestHelpers::JsonHelper
@@ -72,28 +72,28 @@ class AuthTest < MiniTest::Test
       {
         expect: Role.admin,
         post: {
-            username: "acain",
+            username: "aadmin",
             password: "password"
         }
       },
       {
         expect: Role.convenor,
         post: {
-            username: "jrenzella",
+            username: "aconvenor",
             password: "password"
         }
       },
       {
         expect: Role.tutor,
         post: {
-            username: "rwilson",
+            username: "atutor",
             password: "password"
         }
       },
       {
         expect: Role.student,
         post: {
-            username: "acummaudo",
+            username: "astudent",
             password: "password"
         }
       }

--- a/test/api/units_test.rb
+++ b/test/api/units_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'date'
 
-class UnitsTest < MiniTest::Test
+class UnitsTest < ActiveSupport::TestCase
   include Rack::Test::Methods
   include TestHelpers::AuthHelper
   include TestHelpers::JsonHelper

--- a/test/api/units_test.rb
+++ b/test/api/units_test.rb
@@ -10,10 +10,6 @@ class UnitsTest < ActiveSupport::TestCase
     Rails.application
   end
 
-  def setup
-    @auth_token = get_auth_token()
-  end
-
   # --------------------------------------------------------------------------- #
   # --- Endpoint testing for:
   # ------- /api/units.json

--- a/test/api/units_test.rb
+++ b/test/api/units_test.rb
@@ -36,7 +36,7 @@ class UnitsTest < ActiveSupport::TestCase
     post_json '/api/units.json', data_to_post
 
     # Check to see if the unit's name matches what was expected
-    actual_unit = JSON.parse(last_response.body)
+    actual_unit = last_response_body
 
     assert_equal expected_unit[:name], actual_unit['name']
     assert_equal expected_unit[:code], actual_unit['code']
@@ -76,16 +76,16 @@ class UnitsTest < ActiveSupport::TestCase
     #       '"auth_token":' + '"' + @auth_token + '"'         +
     #       '}', "CONTENT_TYPE" => 'application/json'
 
-    # puts JSON.parse(last_response.body)
+    # puts last_response_body
 
     # # Check to see if the unit's name matches what was expected
-    # assert_equal JSON.parse(last_response.body)['name'], 'Intro to Social Skills'
+    # assert_equal last_response_body['name'], 'Intro to Social Skills'
     # # Check to see if the unit's code matches what was expected
-    # assert_equal JSON.parse(last_response.body)['code'], 'JRRW40003'
+    # assert_equal last_response_body['code'], 'JRRW40003'
     # # Check to see if the unit's stat date matches what was expected
-    # assert_equal JSON.parse(last_response.body)['start_date'], '2016-05-14T00:00:00.000Z'
+    # assert_equal last_response_body['start_date'], '2016-05-14T00:00:00.000Z'
     # # Check to see if the unit's end date matches what was expected
-    # assert_equal JSON.parse(last_response.body)['end_date'], '2017-05-14T00:00:00.000Z'
+    # assert_equal last_response_body['end_date'], '2017-05-14T00:00:00.000Z'
   end
   # End POST tests
   # --------------------------------------------------------------------------- #
@@ -98,7 +98,7 @@ class UnitsTest < ActiveSupport::TestCase
     # The GET we are testing
     get with_auth_token "/api/units.json"
 
-    actual_unit = JSON.parse(last_response.body)[0]
+    actual_unit = last_response_body[0]
     expected_unit = Unit.first
     assert_equal expected_unit.name, actual_unit['name']
     assert_equal expected_unit.code, actual_unit['code']
@@ -106,7 +106,7 @@ class UnitsTest < ActiveSupport::TestCase
     assert_equal expected_unit.end_date.to_date, actual_unit['end_date'].to_date.to_date
 
     # Check last unit in Units (created in seed.db)
-    actual_unit = JSON.parse(last_response.body)[1]
+    actual_unit = last_response_body[1]
     expected_unit = Unit.find(2)
 
     assert_equal expected_unit.name, actual_unit['name']
@@ -122,7 +122,7 @@ class UnitsTest < ActiveSupport::TestCase
     # Test getting the first unit with id of 1
     get with_auth_token "/api/units/1.json"
 
-    actual_unit = JSON.parse(last_response.body)
+    actual_unit = last_response_body
     expected_unit = Unit.find(1)
 
     # Check to see if the first unit's match
@@ -135,7 +135,7 @@ class UnitsTest < ActiveSupport::TestCase
     # Test getting the first unit with id of 2
     get with_auth_token "/api/units/2.json"
 
-    actual_unit = JSON.parse(last_response.body)
+    actual_unit = last_response_body
     expected_unit = Unit.find(2)
 
     # Check to see if the first unit's match
@@ -213,7 +213,7 @@ class UnitsTest < ActiveSupport::TestCase
     # })
     # put "/api/units/#{unit_id}.json", data_to_put.to_json, "CONTENT_TYPE" => 'application/json'
     #
-    # actual_unit = JSON.parse(last_response.body)
+    # actual_unit = last_response_body
     # expected_unit = data_to_put
     #
     # puts actual_unit

--- a/test/api/units_test.rb
+++ b/test/api/units_test.rb
@@ -96,7 +96,7 @@ class UnitsTest < ActiveSupport::TestCase
   # Test GET for getting all units
   def test_units_get
     # The GET we are testing
-    get "/api/units.json?auth_token=#{@auth_token}"
+    get with_auth_token "/api/units.json"
 
     actual_unit = JSON.parse(last_response.body)[0]
     expected_unit = Unit.first
@@ -120,7 +120,7 @@ class UnitsTest < ActiveSupport::TestCase
     # Get response back from getting a unit by id
 
     # Test getting the first unit with id of 1
-    get  "/api/units/1.json?auth_token=#{@auth_token}"
+    get with_auth_token "/api/units/1.json"
 
     actual_unit = JSON.parse(last_response.body)
     expected_unit = Unit.find(1)
@@ -133,7 +133,7 @@ class UnitsTest < ActiveSupport::TestCase
 
     # Get response back from getting a unit by id
     # Test getting the first unit with id of 2
-    get  "/api/units/2.json?auth_token=#{@auth_token}"
+    get with_auth_token "/api/units/2.json"
 
     actual_unit = JSON.parse(last_response.body)
     expected_unit = Unit.find(2)

--- a/test/helpers/auth_helper.rb
+++ b/test/helpers/auth_helper.rb
@@ -4,16 +4,9 @@ module TestHelpers
   #
   module AuthHelper
     #
-    # Gets an authentication token for User.first
-    #
-    def auth_token
-      auth_token_for_user(User.first)
-    end
-
-    #
     # Gets an auth token for the provided user
     #
-    def auth_token_for_user(user)
+    def auth_token(user = User.first)
       user.extend_authentication_token(true)
       user.auth_token
     end
@@ -43,7 +36,6 @@ module TestHelpers
 
     module_function :auth_token
     module_function :add_auth_token
-    module_function :auth_token_for_user
     module_function :with_auth_token
   end
 end

--- a/test/helpers/auth_helper.rb
+++ b/test/helpers/auth_helper.rb
@@ -12,6 +12,11 @@ module TestHelpers
       user.auth_token
     end
 
+    def auth_token_for(user)
+      user.extend_authentication_token(true)
+      user.auth_token
+    end
+
     #
     # Adds an authentication token to the hash of data provided
     # This prevents us from having to keep adding the :auth_token

--- a/test/helpers/auth_helper.rb
+++ b/test/helpers/auth_helper.rb
@@ -7,7 +7,7 @@ module TestHelpers
     # Gets an authentication token for User.first
     #
     def auth_token
-      auth_token_for(User.first)
+      auth_token_for_user(User.first)
     end
 
     #

--- a/test/helpers/auth_helper.rb
+++ b/test/helpers/auth_helper.rb
@@ -37,12 +37,13 @@ module TestHelpers
     #
     # Alias for above for nicer usage (e.g., get with_auth_token "http://")
     #
-    def with_auth_token(data)
-      add_auth_token data
+    def with_auth_token(data, user = User.first)
+      add_auth_token data, user
     end
 
     module_function :auth_token
     module_function :add_auth_token
     module_function :auth_token_for_user
+    module_function :with_auth_token
   end
 end

--- a/test/helpers/auth_helper.rb
+++ b/test/helpers/auth_helper.rb
@@ -6,28 +6,43 @@ module TestHelpers
     #
     # Gets an authentication token for User.first
     #
-    def get_auth_token
-      user = User.first
-      user.extend_authentication_token(true)
-      user.auth_token
+    def auth_token
+      auth_token_for(User.first)
     end
 
-    def auth_token_for(user)
+    #
+    # Gets an auth token for the provided user
+    #
+    def auth_token_for_user(user)
       user.extend_authentication_token(true)
       user.auth_token
     end
 
     #
-    # Adds an authentication token to the hash of data provided
+    # Adds an authentication token to the hash data or string URL
     # This prevents us from having to keep adding the :auth_token
-    # key to any POST data that is needed
+    # key to any GET/POST/PUT etc. data that is needed
     #
-    def add_auth_token(hash)
-      hash[:auth_token] = get_auth_token
-      hash
+    def add_auth_token(data, user = User.first)
+      if data.is_a? Hash
+        data[:auth_token] = auth_token
+      elsif data.is_a? String
+        # If we have a question mark, we need to add a query paramater using &
+        # otherwise use ?
+        data << (data.include?('?') ? "&" : "?") << "auth_token=#{auth_token}"
+      end
+      data
     end
 
-    module_function :get_auth_token
+    #
+    # Alias for above for nicer usage (e.g., get with_auth_token "http://")
+    #
+    def with_auth_token(data)
+      add_auth_token data
+    end
+
+    module_function :auth_token
     module_function :add_auth_token
+    module_function :auth_token_for_user
   end
 end

--- a/test/helpers/auth_helper.rb
+++ b/test/helpers/auth_helper.rb
@@ -17,8 +17,10 @@ module TestHelpers
     # key to any GET/POST/PUT etc. data that is needed
     #
     def add_auth_token(data, user = User.first)
+      # Passed in an id instead of a user model? Find the user model from User.find
+      user = User.find(user) if user.is_a? Fixnum
       if data.is_a? Hash
-        data[:auth_token] = auth_token
+        data[:auth_token] = auth_token user
       elsif data.is_a? String
         # If we have a question mark, we need to add a query paramater using &
         # otherwise use ?

--- a/test/helpers/json_helper.rb
+++ b/test/helpers/json_helper.rb
@@ -27,8 +27,32 @@ module TestHelpers
       keys.each { |k| assert_equal model[k], response_json[k], "Values for key #{k} match" }
     end
 
+    #
+    # Last response body parsed from JSON
+    #
+    def last_response_body
+      JSON.parse(last_response.body)
+    end
+
+    #
+    # Converts from an ActiveRelation to JSON (without Ruby objects inside the hash)
+    #
+    def json_hashed(hash)
+      JSON.parse(hash.to_json)
+    end
+
+    #
+    # Assert that the lefthand matches the right-hand as json hash
+    #
+    def assert_json_equal(lhs, rhs)
+      assert_equal json_hashed(lhs), json_hashed(rhs)
+    end
+
     module_function :assert_json_matches_model
     module_function :post_json
     module_function :put_json
+    module_function :last_response_body
+    module_function :json_hashed
+    module_function :assert_json_equal
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,8 +17,8 @@ end
 # Require minitest extensions
 require 'minitest/rails'
 require 'minitest/pride'
-require 'minitest/autorun'
 require 'minitest/osx'
+require 'minitest/around'
 
 # Require all test helpers
 require_all 'test/helpers'
@@ -26,7 +26,6 @@ require 'rails/test_help'
 require 'database_cleaner'
 
 class ActiveSupport::TestCase
-  # Check if migrations are pending
   ActiveRecord::Migration.check_pending!
 
   # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.
@@ -41,17 +40,20 @@ class ActiveSupport::TestCase
   # Support rollback of db changes after all tests
   DatabaseCleaner.strategy = :transaction
 
-  # After setup of all test, start database cleaner to undo transactions
-  def before_teardown
-    super
+  def setup
     DatabaseCleaner.start
   end
 
-  # After teardown
-  def after_teardown
+  def teardown
     DatabaseCleaner.clean
-    super
   end
 
   # Add more helper methods to be used by all tests here...
+  require_all 'test/helpers'
+
+  extend MiniTest::Spec::DSL
+
+  register_spec_type self do |desc|
+    desc < ActiveRecord::Base if desc_is_a? Class
+  end
 end


### PR DESCRIPTION
@jakerenzella and myself worked on fixing the test framework to ensure all tests use minitest and that transactions are used on our [new/helpdesk-ticketing](https://github.com/final-year-project/doubtfire-api/tree/new/helpdesk-ticketing) branch. This pull request cherry-picks those commits into this branch so that it can be implemented in [develop](https://github.com/doubtfire-api/doubtfire-api/tree/develop)