### PR TITLE
Redirect users back to front end after validating JWT

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,6 @@ GEM
     devise_ldap_authenticatable (0.8.5)
       devise (>= 3.4.1)
       net-ldap (>= 0.6.0, <= 0.11)
-    diff-lcs (1.2.5)
     dotenv (2.1.1)
     dotenv-rails (2.1.1)
       dotenv (= 2.1.1)
@@ -252,8 +251,8 @@ DEPENDENCIES
   grape-active_model_serializers (~> 1.3.2)
   grape-swagger
   hirb
-  minitest-around
   json-jwt (= 1.7.0)
+  minitest-around
   minitest-hyper
   minitest-osx
   minitest-rails

--- a/app/helpers/authentication_helpers.rb
+++ b/app/helpers/authentication_helpers.rb
@@ -30,6 +30,7 @@ module AuthenticationHelpers
       sleep((200 + rand(200)) / 1000.0)
       error!({ error: 'Could not authenticate with token. Token invalid.' }, 419)
     end
+    user_by_token
   end
 
   #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,18 +108,9 @@ class User < ActiveRecord::Base
     token
   end
 
-  #
-  # Generates a new authentication token if it has expired or extends the time
-  # an existing authentication token if it has not.
-  #
-  def revise_authentication_token(remember)
-    if authentication_token_expired?
-      # Create a new token
-      generate_authentication_token! remember
-    else
-      # Extend the existing token's time
-      extend_authentication_token remember
-    end
+  def generate_temporary_authentication_token!
+    generate_authentication_token!(false)
+    self.auth_token_expiry = Time.zone.now + 30.seconds
   end
 
   #


### PR DESCRIPTION
Prevents users from seeing a API JSON response after they have authenticated via AAF.

```
[WEB]          [API]             [AFF]
 |------------------------------->|         (1)
                |<----------------|         (2)
 |<-------------|                           (3)
 |------------->|                           (4)
 |<-------------|                           (5)
```

Where:

1) ask AAF to authenticate the user
2) AFF sends its callback to the API
3) API redirects back to the web UI using temporary auth token (that'll expire in 30 seconds)
4) use temporary auth token or to get user details and invalidate it
5) respond back equivalent of `POST /auth` (username/password request)