### PR TITLE
FIX: Only use password field in User if AAF is not enabled

### DIFF
--- a/lib/helpers/database_populator.rb
+++ b/lib/helpers/database_populator.rb
@@ -87,10 +87,14 @@ class DatabasePopulator
       profile[:username]  ||= username
       profile[:login_id]  ||= username
 
-      user = User.create!(profile.merge({
-        password: 'password',
-        password_confirmation: 'password'
-      }))
+      if AuthenticationHelpers.aaf_auth?
+        user = User.create!(profile)
+      else
+        user = User.create!(profile.merge({
+          password: 'password',
+          password_confirmation: 'password'
+        }))
+      end
 
       @user_cache[user_key] = user
     end

--- a/lib/helpers/find_or_create_students.rb
+++ b/lib/helpers/find_or_create_students.rb
@@ -5,16 +5,27 @@ def find_or_create_student(username)
   user_created = nil
   using_cache = !!@user_cache
   if !using_cache || !@user_cache.key?(username)
-    profile = {
-      first_name:             Faker::Name.first_name,
-      last_name:              Faker::Name.last_name,
-      nickname:               username,
-      role_id:                Role.student_id,
-      email:                  "#{username}@doubtfire.com",
-      username:               username,
-      password:               'password',
-      password_confirmation:  'password'
-    }
+    if AuthenticationHelpers.aaf_auth?
+      profile = {
+        first_name:             Faker::Name.first_name,
+        last_name:              Faker::Name.last_name,
+        nickname:               username,
+        role_id:                Role.student_id,
+        email:                  "#{username}@doubtfire.com",
+        username:               username,
+      }
+    else
+      profile = {
+        first_name:             Faker::Name.first_name,
+        last_name:              Faker::Name.last_name,
+        nickname:               username,
+        role_id:                Role.student_id,
+        email:                  "#{username}@doubtfire.com",
+        username:               username,
+        password:               'password',
+        password_confirmation:  'password'
+      }
+    end
     user_created = User.create!(profile)
     @user_cache[username] = user_created if using_cache
   end

--- a/lib/helpers/find_or_create_students.rb
+++ b/lib/helpers/find_or_create_students.rb
@@ -6,12 +6,12 @@ def find_or_create_student(username)
   using_cache = !@user_cache.nil?
   if !using_cache || !@user_cache.key?(username)
     profile = {
-        first_name:             Faker::Name.first_name,
-        last_name:              Faker::Name.last_name,
-        nickname:               username,
-        role_id:                Role.student_id,
-        email:                  "#{username}@doubtfire.com",
-        username:               username
+      first_name:             Faker::Name.first_name,
+      last_name:              Faker::Name.last_name,
+      nickname:               username,
+      role_id:                Role.student_id,
+      email:                  "#{username}@doubtfire.com",
+      username:               username
     }
     if !AuthenticationHelpers.aaf_auth?
       profile[:password] = 'password'

--- a/lib/helpers/find_or_create_students.rb
+++ b/lib/helpers/find_or_create_students.rb
@@ -13,7 +13,7 @@ def find_or_create_student(username)
       email:                  "#{username}@doubtfire.com",
       username:               username
     }
-    if !AuthenticationHelpers.aaf_auth?
+    unless AuthenticationHelpers.aaf_auth?
       profile[:password] = 'password'
       profile[:password_confirmation] = 'password'
     end

--- a/lib/helpers/find_or_create_students.rb
+++ b/lib/helpers/find_or_create_students.rb
@@ -5,26 +5,17 @@ def find_or_create_student(username)
   user_created = nil
   using_cache = !!@user_cache
   if !using_cache || !@user_cache.key?(username)
-    if AuthenticationHelpers.aaf_auth?
-      profile = {
+    profile = {
         first_name:             Faker::Name.first_name,
         last_name:              Faker::Name.last_name,
         nickname:               username,
         role_id:                Role.student_id,
         email:                  "#{username}@doubtfire.com",
-        username:               username,
-      }
-    else
-      profile = {
-        first_name:             Faker::Name.first_name,
-        last_name:              Faker::Name.last_name,
-        nickname:               username,
-        role_id:                Role.student_id,
-        email:                  "#{username}@doubtfire.com",
-        username:               username,
-        password:               'password',
-        password_confirmation:  'password'
-      }
+        username:               username
+    }
+    if !AuthenticationHelpers.aaf_auth?
+      profile[:password] = 'password'
+      profile[:password_confirmation] = 'password'
     end
     user_created = User.create!(profile)
     @user_cache[username] = user_created if using_cache

--- a/lib/helpers/find_or_create_students.rb
+++ b/lib/helpers/find_or_create_students.rb
@@ -3,7 +3,7 @@
 #
 def find_or_create_student(username)
   user_created = nil
-  using_cache = !!@user_cache
+  using_cache = !@user_cache.nil?
   if !using_cache || !@user_cache.key?(username)
     profile = {
         first_name:             Faker::Name.first_name,


### PR DESCRIPTION
This PR will ensure that the database populator is successful when AAF is enabled by not assigning a password to the password field on a User (which does not exist if AAF is enabled)