### PR TITLE
Fix issues with groups and assign number to groups for reference

### DIFF
--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -171,7 +171,8 @@ module Api
           group_params[:name] = "Group #{id}"
         end
       end
-      grp = Group.create(name: group_params[:name], group_set: group_set, tutorial: tutorial)
+      num = group_set.groups.last.number + 1
+      grp = Group.create(name: group_params[:name], group_set: group_set, tutorial: tutorial, number: num)
       grp.save!
       grp
     end

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -294,16 +294,16 @@ module Api
 
     desc 'Remove a group member'
     params do
-      requires :unit_id,                            type: Integer,  desc: 'The unit for the new group'
-      requires :group_set_id,                       type: Integer,  desc: 'The id of the group set'
-      requires :group_id,                           type: Integer,  desc: 'The id of the group'
-      requires :id,                                 type: Integer,  desc: 'The project id of the member'
+      requires :unit_id,      type: Integer,  desc: 'The unit for the new group'
+      requires :group_set_id, type: Integer,  desc: 'The id of the group set'
+      requires :group_id,     type: Integer,  desc: 'The id of the group'
+      requires :project_id,   type: Integer,  desc: 'The project id of the member'
     end
     delete '/units/:unit_id/group_sets/:group_set_id/groups/:group_id/members/:id' do
       unit = Unit.find(params[:unit_id])
       gs = unit.group_sets.find(params[:group_set_id])
       grp = gs.groups.find(params[:group_id])
-      prj = grp.projects.find(params[:id])
+      prj = grp.projects.find(params[:project_id])
 
       unless authorise? current_user, grp, :manage_group, ->(role, perm_hash, other) { grp.specific_permission_hash(role, perm_hash, other) }
         error!({ error: 'Not authorised to manage this group' }, 403)

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -168,7 +168,7 @@ module Api
         error!({ error: "This group name is not unique to the #{group_set.name} group set." }, 403)
       end
 
-      num = group_set.groups.count + 1
+      num = group_set.groups.last.number + 1
       if group_params[:name].nil? || group_params[:name].empty?
         group_params[:name] = "Group #{num}"
       end

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -217,6 +217,11 @@ module Api
         error!({ error: 'Not authorised to update this group' }, 403)
       end
 
+      # Switching tutorials will violate any existing group members
+      if !grp.group_memberships.empty? && params[:tutorial_id] != grp.tutorial.id && gs.keep_groups_in_same_class
+        error!({ error: 'Cannot modify group tutorial as members already exist and they must be in the same tutorial. Clear all members first.' }, 403)
+      end
+
       group_params = ActionController::Parameters.new(params)
                                                  .require(:group)
                                                  .permit(

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -235,9 +235,9 @@ module Api
 
     desc 'Delete a group'
     params do
-      requires :unit_id,                            type: Integer,  desc: 'The unit for the new group'
-      requires :group_set_id,                       type: Integer,  desc: 'The id of the group set'
-      requires :group_id,                           type: Integer,  desc: 'The id of the group'
+      requires :unit_id,      type: Integer,  desc: 'The unit for the new group'
+      requires :group_set_id, type: Integer,  desc: 'The id of the group set'
+      requires :group_id,     type: Integer,  desc: 'The id of the group'
     end
     delete '/units/:unit_id/group_sets/:group_set_id/groups/:group_id' do
       unit = Unit.find(params[:unit_id])
@@ -292,6 +292,10 @@ module Api
 
       unless authorise? current_user, prj, :get
         error!({ error: 'Not authorised to manage this student' }, 403)
+      end
+
+      if gs.keep_groups_in_same_class && prj.tutorial != grp.tutorial
+        error!({ error: "tudents from the tutorial '#{grp.tutorial.abbreviation}' can only be added to this group." }, 403)
       end
 
       if grp.group_memberships.find_by(project: prj)

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -168,7 +168,8 @@ module Api
         error!({ error: "This group name is not unique to the #{group_set.name} group set." }, 403)
       end
 
-      num = group_set.groups.last.number + 1
+      last = group_set.groups.last
+      num = last.nil? ? 1 : last.number + 1
       if group_params[:name].nil? || group_params[:name].empty?
         group_params[:name] = "Group #{num}"
       end

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -309,16 +309,16 @@ module Api
 
     desc 'Remove a group member'
     params do
-      requires :unit_id,      type: Integer,  desc: 'The unit for the new group'
-      requires :group_set_id, type: Integer,  desc: 'The id of the group set'
-      requires :group_id,     type: Integer,  desc: 'The id of the group'
-      requires :project_id,   type: Integer,  desc: 'The project id of the member'
+      requires :unit_id,                            type: Integer,  desc: 'The unit for the new group'
+      requires :group_set_id,                       type: Integer,  desc: 'The id of the group set'
+      requires :group_id,                           type: Integer,  desc: 'The id of the group'
+      requires :id,                                 type: Integer,  desc: 'The project id of the member'
     end
     delete '/units/:unit_id/group_sets/:group_set_id/groups/:group_id/members/:id' do
       unit = Unit.find(params[:unit_id])
       gs = unit.group_sets.find(params[:group_set_id])
       grp = gs.groups.find(params[:group_id])
-      prj = grp.projects.find(params[:project_id])
+      prj = grp.projects.find(params[:id])
 
       unless authorise? current_user, grp, :manage_group, ->(role, perm_hash, other) { grp.specific_permission_hash(role, perm_hash, other) }
         error!({ error: 'Not authorised to manage this group' }, 403)

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -163,15 +163,14 @@ module Api
                                                    :name
                                                  )
 
+      num = group_set.groups.count + 1
       if group_params[:name].nil? || group_params[:name].empty?
-        id = group_set.groups.count
-        group_params[:name] = "Group #{id}"
+        group_params[:name] = "Group #{num}"
         while group_set.groups.where(name: group_params[:name]).count > 0
-          id += 1
-          group_params[:name] = "Group #{id}"
+          num += 1
+          group_params[:name] = "Group #{num}"
         end
       end
-      num = group_set.groups.last.number + 1
       grp = Group.create(name: group_params[:name], group_set: group_set, tutorial: tutorial, number: num)
       grp.save!
       grp

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -319,6 +319,10 @@ module Api
         error!({ error: 'Not authorised to manage this student' }, 403)
       end
 
+      if grp.group_memberships.find_by(project: prj).nil?
+        error!({ error: "#{prj.student.name} is not a member of this group" }, 403)
+      end
+
       grp.remove_member(prj)
       nil
     end

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -289,6 +289,10 @@ module Api
         error!({ error: 'Not authorised to manage this student' }, 403)
       end
 
+      if grp.group_memberships.find_by(project: prj)
+        error!({ error: "#{prj.student.name} is already a member of this group" }, 403)
+      end
+
       gm = grp.add_member(prj)
       Thread.current[:user] = current_user
       GroupMemberProjectSerializer.new(prj)

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -298,7 +298,7 @@ module Api
         error!({ error: "tudents from the tutorial '#{grp.tutorial.abbreviation}' can only be added to this group." }, 403)
       end
 
-      if grp.group_memberships.find_by(project: prj)
+      if grp.group_memberships.find_by(project: prj, active: true)
         error!({ error: "#{prj.student.name} is already a member of this group" }, 403)
       end
 

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -295,7 +295,7 @@ module Api
       end
 
       if gs.keep_groups_in_same_class && prj.tutorial != grp.tutorial
-        error!({ error: "tudents from the tutorial '#{grp.tutorial.abbreviation}' can only be added to this group." }, 403)
+        error!({ error: "Students from the tutorial '#{grp.tutorial.abbreviation}' can only be added to this group." }, 403)
       end
 
       if grp.group_memberships.find_by(project: prj, active: true)

--- a/app/api/group_sets.rb
+++ b/app/api/group_sets.rb
@@ -163,13 +163,14 @@ module Api
                                                    :name
                                                  )
 
+      # Group with the same name
+      unless group_set.groups.where(name: group_params[:name]).empty?
+        error!({ error: "This group name is not unique to the #{group_set.name} group set." }, 403)
+      end
+
       num = group_set.groups.count + 1
       if group_params[:name].nil? || group_params[:name].empty?
         group_params[:name] = "Group #{num}"
-        while group_set.groups.where(name: group_params[:name]).count > 0
-          num += 1
-          group_params[:name] = "Group #{num}"
-        end
       end
       grp = Group.create(name: group_params[:name], group_set: group_set, tutorial: tutorial, number: num)
       grp.save!

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -12,9 +12,12 @@ class Group < ActiveRecord::Base
   has_one :tutor, through: :tutorial
 
   validates :name, presence: true, allow_nil: false
+  validates :number, presence: true, allow_nil: false
   validates :group_set, presence: true, allow_nil: false
   validates :tutorial, presence: true, allow_nil: false
   validates_associated :group_memberships
+  validates :number, uniqueness: { scope: :group_set,
+                                 message: 'must be unique within the set of groups' }
   validates :name, uniqueness: { scope: :group_set,
                                  message: 'must be unique within the set of groups' }
   validate :must_be_in_same_tutorial, if: :limit_members_to_tutorial?

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -616,7 +616,7 @@ class Unit < ActiveRecord::Base
       next if row[0] =~ /^(group_name)|(name)/ # Skip header
 
       begin
-        missing = missing_headers(row, %w(group_name username tutorial))
+        missing = missing_headers(row, %w(group_name group_number username tutorial))
         if missing.count > 0
           errors << { row: row, message: "Missing headers: #{missing.join(', ')}" }
           next
@@ -624,6 +624,7 @@ class Unit < ActiveRecord::Base
 
         username = row['username'].downcase.strip unless row['username'].nil?
         group_name = row['group_name'].strip unless row['group_name'].nil?
+        group_number = row['group_number'].strip unless row['group_number'].nil?
         tutorial = row['tutorial'].strip unless row['tutorial'].nil?
 
         user = User.where(username: username).first
@@ -653,6 +654,7 @@ class Unit < ActiveRecord::Base
 
           change = 'Created new group. '
           grp.tutorial = tutorial
+          grp.number = group_number
           grp.save!
         end
 
@@ -680,7 +682,7 @@ class Unit < ActiveRecord::Base
       row << %w(group_name username tutorial)
       group_set.groups.each do |grp|
         grp.projects.each do |project|
-          row << [grp.name, project.student.username, grp.tutorial.abbreviation]
+          row << [grp.name, grp.number, project.student.username, grp.tutorial.abbreviation]
         end
       end
     end

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -1,3 +1,3 @@
 class GroupSerializer < ActiveModel::Serializer
-  attributes :id, :name, :tutorial_id, :group_set_id
+  attributes :id, :name, :tutorial_id, :group_set_id, :number
 end

--- a/db/migrate/20170116035300_add_group_number.rb
+++ b/db/migrate/20170116035300_add_group_number.rb
@@ -1,5 +1,5 @@
 class AddGroupNumber < ActiveRecord::Migration
   def change
-    add_column :groups, :group_number, :integer, null: false, unique: true
+    add_column :groups, :number, :integer, null: false, unique: true
   end
 end

--- a/db/migrate/20170116035300_add_group_number.rb
+++ b/db/migrate/20170116035300_add_group_number.rb
@@ -1,0 +1,5 @@
+class AddGroupNumber < ActiveRecord::Migration
+  def change
+    add_column :groups, :group_number, :integer, null: false, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161208055326) do
+ActiveRecord::Schema.define(version: 20170116035300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 20161208055326) do
     t.string   "name",         limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "group_number",             null: false
   end
 
   create_table "helpdesk_schedules", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20170116035300) do
     t.string   "name",         limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "group_number",             null: false
+    t.integer  "number",                   null: false
   end
 
   create_table "helpdesk_schedules", force: :cascade do |t|

--- a/test_files/COS10001-TestImportGroups.csv
+++ b/test_files/COS10001-TestImportGroups.csv
@@ -1,6 +1,6 @@
-group_name,username,tutorial
-TEST_GROUP_1,test_student_8,LA1-02
-TEST_GROUP_1,test_student_7,LA1-02
-TEST_GROUP_2,test_student_5,LA1-02
-TEST_GROUP_2,test_student_9,LA1-02
-TEST_GROUP_3,test_student_6,LA1-02
+group_name,group_number,username,tutorial
+TEST_GROUP_1,1,test_student_8,LA1-02
+TEST_GROUP_1,2,test_student_7,LA1-02
+TEST_GROUP_2,3,test_student_5,LA1-02
+TEST_GROUP_2,4,test_student_9,LA1-02
+TEST_GROUP_3,5,test_student_6,LA1-02

--- a/test_files/group_upload.csv
+++ b/test_files/group_upload.csv
@@ -1,10 +1,10 @@
-group_name, username, tutorial,,,
-Group 1, student_1, LA1-01,,,
-Group 1, student_2, LA1-01
-Group 2, student_3, LA1-01
-Group 2, student_4, LA1-01
+group_name,group_number,username, tutorial
+Group 1,1, student_1, LA1-01
+Group 1,2, student_2, LA1-01
+Group 2,3, student_3, LA1-01
+Group 2,4, student_4, LA1-01
 ,student_5,LA1-02
-Group 3, student_1, LA1-01
-Group 3, student_1, LA1-99
+Group 3,5, student_1, LA1-01
+Group 3,6, student_1, LA1-99
 Rubish Row,,
-,,,,,
+,,


### PR DESCRIPTION
Adds a `group_number` concept so that a group may have a name and a consistent number.

Also fixes a number of issues:
- remove group member if not part of group fixed
- prevent switching a group's tutorial if the group set does not allow groups to be part of multiple tutorials
- ensures students from the _right_ tutorial can only be added to a tutorial (given non-mixed tutorial groupset)
- prevent member from being added to group twice