### PR TITLE
Add optional argument to download PDF as attachment

### DIFF
--- a/app/api/submission/portfolio_api.rb
+++ b/app/api/submission/portfolio_api.rb
@@ -65,6 +65,9 @@ module Api
       end
 
       desc 'Retrieve portfolio for project with the given id'
+      params do
+        optional :as_attachment, type: Boolean, desc: 'Whether or not to download file as attachment. Default is false.'
+      end
       get '/submission/project/:id/portfolio' do
         project = Project.find(params[:id])
 
@@ -74,11 +77,13 @@ module Api
 
         evidence_loc = project.portfolio_path
 
-        if evidence_loc.nil? || File.exist?(evidence_loc) == false
-          evidence_loc = Rails.root.join('public', 'resources', 'FileNotFound.pdf')
-          header['Content-Disposition'] = 'attachment; filename=FileNotFound.pdf'
-        else
-          header['Content-Disposition'] = 'attachment; filename=portfolio.pdf'
+        if params[:as_attachment]
+          if evidence_loc.nil? || File.exist?(evidence_loc) == false
+            evidence_loc = Rails.root.join('public', 'resources', 'FileNotFound.pdf')
+            header['Content-Disposition'] = 'attachment; filename=FileNotFound.pdf'
+          else
+            header['Content-Disposition'] = 'attachment; filename=portfolio.pdf'
+          end
         end
 
         # Set download headers...


### PR DESCRIPTION
This PR fixes issues in https://github.com/doubtfire-lms/doubtfire-web/pull/81.

The native `object` in Chrome and Firefox must receive a MIME type `application/pdf` **without** the `Content-Disposition` header set as `attachment`. Safari seems to ignore this, which is why it was rendering in Safari.