### PR TITLE
FIX: Add missing CSV header

### DIFF
--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -778,7 +778,7 @@ class Unit < ActiveRecord::Base
 
   def export_groups_to_csv(group_set)
     CSV.generate do |row|
-      row << %w(group_name username tutorial)
+      row << %w(group_name group_number username tutorial)
       group_set.groups.each do |grp|
         grp.projects.each do |project|
           row << [grp.name, grp.number, project.student.username, grp.tutorial.abbreviation]


### PR DESCRIPTION
This PR fixes a bug in the CSV export for groups which meant that the `group_name` was missing from the CSV.