### PR TITLE
Remove git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".git-hooks"]
-	path = .git-hooks
-	url = https://github.com/dstil/git-hooks


### PR DESCRIPTION
Since the DSTIL repository went private, the Travis builds were failing.