### PR TITLE
FIX: Correct posting of comments to group tasks without groups

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+tab_width = 2

--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -21,7 +21,7 @@ module Api
         error!("Unable to find requested #{e.message[/(Couldn't find )(.*)( with)/,2]}", 404)
       else
         logger.error "Unhandled exception: #{e.class}"
-        logger.info "#{e.inspect}"
+        logger.error e.backtrace.join("\n")
         error!("Sorry... something went wrong with your request.", 500)
       end
     end

--- a/app/api/task_definitions.rb
+++ b/app/api/task_definitions.rb
@@ -135,11 +135,11 @@ module Api
           gs = GroupSet.find(params[:task_def][:group_set_id])
           if gs.unit == task_def.unit
             task_def.group_set = gs
-            task_def.save
+            task_def.save!
           end
         else
           task_def.group_set = nil
-          task_def.save
+          task_def.save!
         end
       end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -511,7 +511,7 @@ class Task < ActiveRecord::Base
     lc = comments.last
     return if lc && lc.user == user && lc.comment == text
 
-    ensured_group_submission if group_task?
+    ensured_group_submission if group_task? && group
 
     comment = TaskComment.create
     comment.task = self
@@ -524,7 +524,7 @@ class Task < ActiveRecord::Base
   end
 
   def add_comment_with_attachment(user, tempfile)
-    ensured_group_submission if group_task?
+    ensured_group_submission if group_task? && group
 
     comment = TaskComment.create
     comment.task = self

--- a/test/api/groups_test.rb
+++ b/test/api/groups_test.rb
@@ -71,4 +71,41 @@ class GroupsTest < ActiveSupport::TestCase
     group_set.destroy
   end
 
+  def test_comment_on_group_task_without_group
+    unit = Unit.first
+
+    group_set = GroupSet.create!({name: 'test_comment_without_group', unit: unit})
+    group_set.save!
+
+    td = TaskDefinition.new({
+        unit_id: unit.id,
+        name: 'Task to switch from ind to group after submission',                    
+        description: 'test def',
+        weighting: 4,
+        target_grade: 0,
+        start_date: Time.zone.now - 1.week,
+        target_date: Time.zone.now - 1.day,
+        due_date: Time.zone.now + 1.week,
+        abbreviation: 'TaskSwitchIndGrp',
+        restrict_status_updates: false,
+        upload_requirements: [ { "key" => 'file0', "name" => 'Shape Class', "type" => 'code' } ],
+        plagiarism_warn_pct: 0.8,
+        is_graded: false,
+        max_quality_pts: 0,
+        group_set: group_set
+      })
+    assert td.save!
+
+    project = unit.projects.first
+
+    comment_data = { comment: "Hello World" }
+
+    post_json with_auth_token("/api/projects/#{project.id}/task_def_id/#{td.id}/comments", project.student), comment_data
+
+    assert_equal 201, last_response.status
+
+    td.destroy
+    group_set.destroy
+  end
+
 end


### PR DESCRIPTION
Posting a comment to a group task previously failed, due to inability to ensure group submission. This PR fixes this issue by testing for group presence on comment posting. Side effect will be that these comments are invisible to group prior to the first submission of this task.