### PR TITLE
FIX: Enable comment attachments for group tasks

### DIFF
--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -111,7 +111,7 @@ module FileHelper
   # type = [:new, :in_process, :done, :pdf, :plagarism]
   #
   def student_work_dir(type = nil, task = nil, create = true)
-    if task && task.group_task?
+    if task && task.group_task? && type != :comment
       dst = student_group_work_dir type, task.group_submission, task
     else
       file_server = Doubtfire::Application.config.student_work_dir

--- a/app/models/task_comment.rb
+++ b/app/models/task_comment.rb
@@ -15,9 +15,16 @@ class TaskComment < ActiveRecord::Base
   validates :user, presence: true
   validates :recipient, presence: true
   validates :comment, length: { minimum: 0, maximum: 4095, allow_blank: true }
+  
+  # Delete action - before dependent association
+  before_destroy :delete_associated_files
 
   def new_for?(user)
     CommentsReadReceipts.where(user: user, task_comment_id: self).empty?
+  end
+
+  def delete_associated_files
+    FileUtils.rm attachment_path if File.exists? attachment_path
   end
 
   def create_comment_read_receipt_entry(user)

--- a/test/api/groups_test.rb
+++ b/test/api/groups_test.rb
@@ -108,4 +108,87 @@ class GroupsTest < ActiveSupport::TestCase
     group_set.destroy
   end
 
+  def test_pdf_comment_on_group_task
+    unit = Unit.first
+
+    group_set = GroupSet.create!({name: 'test_comment_without_group', unit: unit})
+    group_set.save!
+
+    group = Group.create!({group_set: group_set, name: 'test_group_submission_with_extensions', tutorial: unit.tutorials.first, number: 0})
+
+    group.add_member(unit.active_projects[0])
+    group.add_member(unit.active_projects[1])
+    group.add_member(unit.active_projects[2])
+
+    td = TaskDefinition.new({
+        unit_id: unit.id,
+        name: 'Task to switch from ind to group after submission',                    
+        description: 'test def',
+        weighting: 4,
+        target_grade: 0,
+        start_date: Time.zone.now - 1.week,
+        target_date: Time.zone.now - 1.day,
+        due_date: Time.zone.now + 1.week,
+        abbreviation: 'TaskSwitchIndGrp',
+        restrict_status_updates: false,
+        upload_requirements: [ { "key" => 'file0', "name" => 'Shape Class', "type" => 'code' } ],
+        plagiarism_warn_pct: 0.8,
+        is_graded: false,
+        max_quality_pts: 0,
+        group_set: group_set
+      })
+    assert td.save!
+
+    project = unit.projects.first
+
+    comment_data = { attachment: Rack::Test::UploadedFile.new('test_files/submissions/00_question.pdf', 'application/pdf') }
+
+    post with_auth_token("/api/projects/#{project.id}/task_def_id/#{td.id}/comments", project.student), comment_data
+
+    assert_equal 201, last_response.status
+    assert File.exists?(TaskComment.last.attachment_path)
+
+    td.destroy
+    group.destroy
+    group_set.destroy
+  end
+
+  def test_pdf_comment_on_group_task_without_group
+    unit = Unit.first
+
+    group_set = GroupSet.create!({name: 'test_comment_without_group', unit: unit})
+    group_set.save!
+
+    td = TaskDefinition.new({
+        unit_id: unit.id,
+        name: 'Task to switch from ind to group after submission',                    
+        description: 'test def',
+        weighting: 4,
+        target_grade: 0,
+        start_date: Time.zone.now - 1.week,
+        target_date: Time.zone.now - 1.day,
+        due_date: Time.zone.now + 1.week,
+        abbreviation: 'TaskSwitchIndGrp',
+        restrict_status_updates: false,
+        upload_requirements: [ { "key" => 'file0', "name" => 'Shape Class', "type" => 'code' } ],
+        plagiarism_warn_pct: 0.8,
+        is_graded: false,
+        max_quality_pts: 0,
+        group_set: group_set
+      })
+    assert td.save!
+
+    project = unit.projects.first
+
+    comment_data = { attachment: Rack::Test::UploadedFile.new('test_files/submissions/00_question.pdf', 'application/pdf') }
+
+    post with_auth_token("/api/projects/#{project.id}/task_def_id/#{td.id}/comments", project.student), comment_data
+
+    assert_equal 201, last_response.status
+
+    td.destroy
+    group_set.destroy
+  end
+
+
 end


### PR DESCRIPTION
Ensure that comments for group tasks are able to resolve paths to attachments. For group tasks, attachments are associated with the student in the file system rather than the group (allowing comments to be added before groups are formed).

Pull request also ensures that comment attachments are deleted when comment is destroyed.