### PR TITLE
Remove an unavailable gem minitest-osx

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'minitest-around'
   gem 'minitest-hyper'
-  gem 'minitest-osx'
   gem 'minitest-rails'
   gem 'byebug'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,9 +133,6 @@ GEM
     minitest-around (0.4.0)
       minitest (~> 5.0)
     minitest-hyper (0.2.0)
-    minitest-osx (0.1.0)
-      minitest (~> 5.4)
-      terminal-notifier (~> 1.6)
     minitest-rails (2.2.1)
       minitest (~> 5.7)
       railties (~> 4.1)
@@ -239,7 +236,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    terminal-notifier (1.6.3)
     thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -281,7 +277,6 @@ DEPENDENCIES
   json-jwt (= 1.7.0)
   minitest-around
   minitest-hyper
-  minitest-osx
   minitest-rails
   moss_ruby (= 1.1.2)
   mysql2

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,6 @@ end
 # Require minitest extensions
 require 'minitest/rails'
 require 'minitest/pride'
-require 'minitest/osx'
 require 'minitest/around'
 
 # Require all test helpers


### PR DESCRIPTION
'minitest-osx' gem has been removed from RubyGems.

https://rubygems.org/gems/minitest-osx
> This gem previously existed, but has been removed by its owner.

Console output:

```
Step 16/19 : RUN bundle install --without production replica
 ---> Running in 651952df1e09
Don't run Bundler as root. Bundler can ask for sudo if it is needed, and
installing your bundle as root will break this application for all non-root
users on this machine.
Fetching gem metadata from https://rubygems.org/.............
Could not find minitest-osx-0.1.0 in any of the sources
ERROR: Service 'api' failed to build: The command '/bin/sh -c bundle install --without production replica' returned a non-zero code: 7
```