### PR TITLE
FIX: Correct issue with titleize stripping blank names

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,18 @@
 require 'bcrypt'
 require 'authorisation_helpers'
 
+# Modify the string class to fix the titilize issue where
+# names could be stripped on import. Eg a blank name entered as "-"
+#
+# encoding: utf-8
+class String
+  def titleize()
+    result = ActiveSupport::Inflector.titleize(self)
+    return self if self.present? && result.blank?
+    return result
+  end
+end
+
 class User < ActiveRecord::Base
   include AuthenticationHelpers
 


### PR DESCRIPTION
Names that were blank but entered as "-" failed to import.