### PR TITLE
FIX: Remove non-printable characters from comments in portfolio

### DIFF
--- a/app/views/portfolio/portfolio_pdf.pdf.erb
+++ b/app/views/portfolio/portfolio_pdf.pdf.erb
@@ -212,7 +212,7 @@ No Tutor
     \begin{tabular}{p{3cm}|p{3cm}|p{9cm}}
       \textbf{Date} & \textbf{Author} & \textbf{Comment} \\ \hline
       <% task.comments.each do |comment| %>
-        <%= lesc comment.created_at.localtime.strftime("%Y/%m/%d %H:%M") %> & <%= lesc comment.user.name %> & <%= lesc comment.comment %> \\
+        <%= lesc comment.created_at.localtime.strftime("%Y/%m/%d %H:%M") %> & <%= lesc comment.user.name %> & <%= lesc comment.comment.gsub(/[^[:print:]]/,'') %> \\
       <% end %>
     \end{tabular}
   <% end %>


### PR DESCRIPTION
Non-printable characters in the portfolio cause the creation of the portfolio to fail. This PR corrects this to ensure the portfolio creation works and these characters are stripped out of comments.