### PR TITLE
FIX: Move tmp files out of tmp

### DIFF
--- a/app/api/submission/batch_task.rb
+++ b/app/api/submission/batch_task.rb
@@ -42,8 +42,8 @@ module Api
         header['Content-Disposition'] = "attachment; filename=#{download_id}.zip"
         env['api.format'] = :binary
 
-        out = File.read(output_zip.path)
-        output_zip.unlink
+        out = File.read(output_zip)
+        File.unlink(output_zip)
         out
       end # get
 

--- a/app/controllers/lecture_resource_downloads_controller.rb
+++ b/app/controllers/lecture_resource_downloads_controller.rb
@@ -36,7 +36,7 @@ class LectureResourceDownloadsController < ApplicationController
     download_id.gsub! /[\\\/]/, '-'
     download_id = FileHelper.sanitized_filename(download_id)
 
-    send_file output_zip.path, content_type: 'application/octet-stream', disposition: "attachment; filename=#{download_id}.zip"
+    send_file output_zip, content_type: 'application/octet-stream', disposition: "attachment; filename=#{download_id}.zip"
   rescue MyException => e
     render json: e.message, status: e.status
   end

--- a/app/controllers/portfolio_downloads_controller.rb
+++ b/app/controllers/portfolio_downloads_controller.rb
@@ -41,15 +41,15 @@ class PortfolioDownloadsController < ApplicationController
     # header['Content-Disposition'] = "attachment; filename=#{download_id}.zip"
     # env['api.format'] = :binary
 
-    logger.debug "Downloading portfolios from #{output_zip.path}"
+    logger.debug "Downloading portfolios from #{output_zip}"
 
-    # out = File.open(output_zip.path, "rb")
+    # out = File.open(output_zip, "rb")
     # output_zip.unlink
     # response_body = out.read
-    # File.binread output_zip.path
+    # File.binread output_zip
     # sending_file = true
 
-    send_file output_zip.path, content_type: 'application/octet-stream', disposition: "attachment; filename=#{download_id}.zip"
+    send_file output_zip, content_type: 'application/octet-stream', disposition: "attachment; filename=#{download_id}.zip"
   rescue MyException => e
     render json: e.message, status: e.status
   end

--- a/app/controllers/task_downloads_controller.rb
+++ b/app/controllers/task_downloads_controller.rb
@@ -43,10 +43,9 @@ class TaskDownloadsController < ApplicationController
     # header['Content-Disposition'] = "attachment; filename=#{download_id}.zip"
     # env['api.format'] = :binary
 
-    logger.debug "Downloading task for #{td.abbreviation} from #{output_zip.path}"
+    logger.debug "Downloading task for #{td.abbreviation} from #{output_zip}"
 
-    send_file output_zip.path, content_type: 'application/octet-stream', disposition: "attachment; filename=#{download_id}.zip"
-    output_zip.close
+    send_file output_zip, content_type: 'application/octet-stream', disposition: "attachment; filename=#{download_id}.zip"
   rescue MyException => e
     render json: e.message, status: e.status
   end

--- a/app/controllers/task_submission_pdfs_controller.rb
+++ b/app/controllers/task_submission_pdfs_controller.rb
@@ -43,10 +43,9 @@ class TaskSubmissionPdfsController < ApplicationController
     # header['Content-Disposition'] = "attachment; filename=#{download_id}.zip"
     # env['api.format'] = :binary
 
-    logger.debug "Downloading task for #{td.abbreviation} from #{output_zip.path}"
+    logger.debug "Downloading task for #{td.abbreviation} from #{output_zip}"
 
-    send_file output_zip.path, content_type: 'application/octet-stream', disposition: "attachment; filename=#{download_id}.zip"
-    output_zip.close
+    send_file output_zip, content_type: 'application/octet-stream', disposition: "attachment; filename=#{download_id}.zip"
   rescue MyException => e
     render json: e.message, status: e.status
   end

--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -80,6 +80,18 @@ module FileHelper
     dst
   end
 
+  def tmp_file_dir()
+    file_server = Doubtfire::Application.config.student_work_dir
+    dst = "#{file_server}/tmp/" # trust the server config and passed in type for paths
+    FileUtils.mkdir_p dst if !Dir.exist? dst
+
+    dst
+  end
+
+  def tmp_file(filename)
+    tmp_file_dir << sanitized_filename(filename)
+  end
+
   def student_group_work_dir(type, group_submission, task = nil, create = false)
     return nil unless group_submission
 
@@ -443,6 +455,8 @@ module FileHelper
   module_function :sanitized_path
   module_function :sanitized_filename
   module_function :task_file_dir_for_unit
+  module_function :tmp_file_dir
+  module_function :tmp_file
   module_function :student_group_work_dir
   module_function :student_work_dir
   module_function :student_portfolio_dir

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1128,10 +1128,12 @@ class Unit < ActiveRecord::Base
   #
   def get_portfolio_zip(current_user)
     # Get a temp file path
-    filename = FileHelper.sanitized_filename("portfolios-#{code}-#{current_user.username}.zip")
-    result = Tempfile.new(filename)
+    filename = FileHelper.sanitized_filename("portfolios-#{code}-#{current_user.username}")
+    result = "#{FileHelper.tmp_file(filename)}.zip"
+
+    File.unlink(result) if File.exists?(result)
     # Create a new zip
-    Zip::File.open(result.path, Zip::File::CREATE) do |zip|
+    Zip::File.open(result, Zip::File::CREATE) do |zip|
       active_projects.each do |project|
         # Skip if no portfolio at this time...
         next unless project.portfolio_available
@@ -1156,10 +1158,12 @@ class Unit < ActiveRecord::Base
   #
   def get_task_resources_zip
     # Get a temp file path
-    filename = FileHelper.sanitized_filename("task-resources-#{code}.zip")
-    result = Tempfile.new(filename)
+    result = FileHelper.tmp_file("task-resources-#{code}.zip")
+
+    File.unlink(result) if File.exists?(result)
+
     # Create a new zip
-    Zip::File.open(result.path, Zip::File::CREATE) do |zip|
+    Zip::File.open(result, Zip::File::CREATE) do |zip|
       task_definitions.each do |td|
         if td.has_task_sheet?
           dst_path = FileHelper.sanitized_filename(td.abbreviation.to_s) + '.pdf'
@@ -1180,13 +1184,14 @@ class Unit < ActiveRecord::Base
   #
   def get_task_submissions_pdf_zip(current_user, td)
     # Get a temp file path
-    filename = FileHelper.sanitized_filename("submissions-#{code}-#{td.abbreviation}-#{current_user.username}-pdfs")
-    result = Tempfile.new([filename, '.zip'])
+    result = FileHelper.tmp_file("submissions-#{code}-#{td.abbreviation}-#{current_user.username}-pdfs.zip")
 
     tasks_with_files = td.related_tasks_with_files
 
+    File.unlink(result) if File.exists?(result)
+
     # Create a new zip
-    Zip::File.open(result.path, Zip::File::CREATE) do |zip|
+    Zip::File.open(result, Zip::File::CREATE) do |zip|
       Dir.mktmpdir do |dir|
         # Extract all of the files...
         tasks_with_files.each do |task|
@@ -1212,13 +1217,14 @@ class Unit < ActiveRecord::Base
   #
   def get_task_submissions_zip(current_user, td)
     # Get a temp file path
-    filename = FileHelper.sanitized_filename("submissions-#{code}-#{td.abbreviation}-#{current_user.username}-files.zip")
-    result = Tempfile.new(filename)
+    result = FileHelper.tmp_file("submissions-#{code}-#{td.abbreviation}-#{current_user.username}-files.zip")
 
     tasks_with_files = td.related_tasks_with_files
 
+    File.unlink(result) if File.exists?(result)
+
     # Create a new zip
-    Zip::File.open(result.path, Zip::File::CREATE) do |zip|
+    Zip::File.open(result, Zip::File::CREATE) do |zip|
       Dir.mktmpdir do |dir|
         # Extract all of the files...
         tasks_with_files.each do |task|
@@ -1978,12 +1984,12 @@ class Unit < ActiveRecord::Base
     # Reject all tasks not for this unit...
     tasks = tasks.reject { |task| task.project.unit.id != id }
 
-    download_id = "#{Time.new.strftime('%Y-%m-%d')}-#{code}-#{user.username}"
-    filename = FileHelper.sanitized_filename("batch_ready_to_mark_#{user.username}.zip")
-    output_zip = Tempfile.new(filename)
+    output_zip = FileHelper.tmp_file("batch_ready_to_mark_#{user.username}.zip")
+
+    File.unlink(output_zip) if File.exists?(output_zip)
 
     # Create a new zip
-    Zip::File.open(output_zip.path, Zip::File::CREATE) do |zip|
+    Zip::File.open(output_zip, Zip::File::CREATE) do |zip|
       csv_str = mark_csv_headers
 
       # Add individual tasks...

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1131,7 +1131,7 @@ class Unit < ActiveRecord::Base
     filename = FileHelper.sanitized_filename("portfolios-#{code}-#{current_user.username}")
     result = "#{FileHelper.tmp_file(filename)}.zip"
 
-    File.unlink(result) if File.exists?(result)
+    return result if File.exists?(result)
     # Create a new zip
     Zip::File.open(result, Zip::File::CREATE) do |zip|
       active_projects.each do |project|
@@ -1160,7 +1160,7 @@ class Unit < ActiveRecord::Base
     # Get a temp file path
     result = FileHelper.tmp_file("task-resources-#{code}.zip")
 
-    File.unlink(result) if File.exists?(result)
+    return result if File.exists?(result)
 
     # Create a new zip
     Zip::File.open(result, Zip::File::CREATE) do |zip|
@@ -1188,7 +1188,7 @@ class Unit < ActiveRecord::Base
 
     tasks_with_files = td.related_tasks_with_files
 
-    File.unlink(result) if File.exists?(result)
+    return result if File.exists?(result)
 
     # Create a new zip
     Zip::File.open(result, Zip::File::CREATE) do |zip|
@@ -1221,7 +1221,7 @@ class Unit < ActiveRecord::Base
 
     tasks_with_files = td.related_tasks_with_files
 
-    File.unlink(result) if File.exists?(result)
+    return result if File.exists?(result)
 
     # Create a new zip
     Zip::File.open(result, Zip::File::CREATE) do |zip|
@@ -1984,9 +1984,9 @@ class Unit < ActiveRecord::Base
     # Reject all tasks not for this unit...
     tasks = tasks.reject { |task| task.project.unit.id != id }
 
-    output_zip = FileHelper.tmp_file("batch_ready_to_mark_#{user.username}.zip")
+    output_zip = FileHelper.tmp_file("batch_ready_to_mark_#{code}_#{user.username}.zip")
 
-    File.unlink(output_zip) if File.exists?(output_zip)
+    return result if File.exists?(output_zip)
 
     # Create a new zip
     Zip::File.open(output_zip, Zip::File::CREATE) do |zip|

--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -1,0 +1,26 @@
+require_all 'lib/helpers'
+
+namespace :maintenance do
+  desc 'Cleanup temporary files'
+  task cleanup: [:environment] do
+    path = FileHelper.tmp_file_dir
+    
+    if Rails.env.development?
+      time_offset = 1.minute
+    else
+      time_offset = 3.hours
+    end
+
+    Dir.foreach(path) do |item|
+      fname = "#{path}#{item}"
+      next if File.directory?(fname)
+      if File.mtime(fname) < DateTime.now - time_offset
+        begin
+          File.delete(fname)
+        rescue
+          puts "Failed to remove temporary file: #{fname}"
+        end
+      end 
+    end
+  end
+end


### PR DESCRIPTION
This PR moves the creation of temporary files to within the student work folder - away from /tmp

A rake maintenance task is added to clean up files within the new tmp folder.