### PR TITLE
FIX: Correct issue with teaching period date changes not propagating to units

### DIFF
--- a/app/models/teaching_period.rb
+++ b/app/models/teaching_period.rb
@@ -17,6 +17,8 @@ class TeachingPeriod < ActiveRecord::Base
 
   validate :validate_end_date_after_start_date, :validate_active_until_after_end_date
 
+  after_update :propogate_date_changes
+
   # Public methods
 
   def add_break(start_date, number_of_weeks)
@@ -153,6 +155,14 @@ class TeachingPeriod < ActiveRecord::Base
   def validate_end_date_after_start_date
     if end_date.present? && start_date.present? && end_date < start_date
       errors.add(:end_date, "should be after the Start date")
+    end
+  end
+
+  def propogate_date_changes
+    return unless start_date_changed? || end_date_changed?
+    
+    units.each do |u|
+      u.update(start_date: self.start_date, end_date: self.end_date)
     end
   end
 end

--- a/test/models/teaching_period_test.rb
+++ b/test/models/teaching_period_test.rb
@@ -246,4 +246,40 @@ class TeachingPeriodTest < ActiveSupport::TestCase
     assert tp.rollover(tp2)
     assert_equal 0, tp.errors.count
   end
+
+  test 'can update teaching period dates' do
+    data = {
+        year: 2019,
+        period: 'T1',
+        start_date: Date.parse('2018-01-01'),
+        end_date: Date.parse('2018-02-01'),
+        active_until: Date.parse('2018-03-01')
+    }
+
+    tp = TeachingPeriod.create(data)
+    assert tp.valid?
+
+    data = {
+      name: 'Unit with TP - to update',
+      code: 'TEST113',
+      teaching_period: tp,
+      description: 'Unit in TP to update dates',
+    }
+
+    unit = Unit.create(data)
+
+    assert unit.valid?
+
+    tp.update(start_date: Date.parse('2018-01-02'))
+
+    assert tp.valid?
+    unit.reload
+    assert unit.valid?
+
+    tp.update(end_date: Date.parse('2018-02-02'))
+
+    assert tp.valid?
+    unit.reload
+    assert unit.valid?
+  end
 end


### PR DESCRIPTION
This PR fixes an issue where updating the dates for a teaching period cause the units to become invalid.