### PR TITLE
FIX: .ceil of an integer not returning what was expected

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -206,7 +206,7 @@ class Task < ActiveRecord::Base
     current_due = raw_extension_date.to_date
 
     diff = deadline - current_due
-    (diff.to_i / 7).ceil
+    (diff.to_f / 7).ceil
   end
 
   # Add an extension to the task


### PR DESCRIPTION
(diff.to_i / 7).ceil was returning 0 if the number of days extension required was less than 7, as the diff was being converted to an int and then ceil'd. So for example a 1 day extension was erroring as it was not allowed any extension.

to_f now applies the ceil correctly, so the above scenario will return the 1 week extension application