### PR TITLE
TEST: Add a helper to get full test file paths

### DIFF
--- a/test/api/comments/comment_test.rb
+++ b/test/api/comments/comment_test.rb
@@ -4,6 +4,7 @@ class CommentTest < ActiveSupport::TestCase
   include Rack::Test::Methods
   include TestHelpers::AuthHelper
   include TestHelpers::JsonHelper
+  include TestHelpers::TestFileHelper
 
   def app
     Rails.application
@@ -50,7 +51,7 @@ class CommentTest < ActiveSupport::TestCase
 
     pre_count = TaskComment.count
 
-    comment_data = { attachment: Rack::Test::UploadedFile.new('test_files/submissions/Deakin_Logo.jpeg', 'image/jpeg') }
+    comment_data = { attachment: upload_file('test_files/submissions/Deakin_Logo.jpeg', 'image/jpeg') }
 
     post with_auth_token("/api/projects/#{project.id}/task_def_id/#{task_definition.id}/comments", user), comment_data
 
@@ -74,7 +75,7 @@ class CommentTest < ActiveSupport::TestCase
 
     pre_count = TaskComment.count
 
-    comment_data = { attachment: Rack::Test::UploadedFile.new('test_files/submissions/unbelievable.gif', 'image/gif') }
+    comment_data = { attachment: upload_file('test_files/submissions/unbelievable.gif', 'image/gif') }
 
     post with_auth_token("/api/projects/#{project.id}/task_def_id/#{task_definition.id}/comments", user), comment_data
 
@@ -99,7 +100,7 @@ class CommentTest < ActiveSupport::TestCase
 
     pre_count = TaskComment.count
 
-    comment_data = { attachment: Rack::Test::UploadedFile.new('test_files/submissions/00_question.pdf', 'application/pdf') }
+    comment_data = { attachment: upload_file('test_files/submissions/00_question.pdf', 'application/pdf') }
 
     post with_auth_token("/api/projects/#{project.id}/task_def_id/#{task_definition.id}/comments", user), comment_data
 
@@ -124,7 +125,7 @@ class CommentTest < ActiveSupport::TestCase
 
     pre_count = TaskComment.count
 
-    comment_data = { attachment: Rack::Test::UploadedFile.new('test_files/submissions/00_question.pdf', 'application/pdf') }
+    comment_data = { attachment: upload_file('test_files/submissions/00_question.pdf', 'application/pdf') }
 
     post with_auth_token("/api/projects/#{project.id}/task_def_id/#{task_definition.id}/comments", user), comment_data
 
@@ -148,7 +149,7 @@ class CommentTest < ActiveSupport::TestCase
 
     pre_count = TaskComment.count
 
-    comment_data = { attachment: Rack::Test::UploadedFile.new('test_files/submissions/boo.png', 'image/png') }
+    comment_data = { attachment: upload_file('test_files/submissions/boo.png', 'image/png') }
 
     post with_auth_token("/api/projects/#{project.id}/task_def_id/#{task_definition.id}/comments", user), comment_data
 

--- a/test/api/csv_test.rb
+++ b/test/api/csv_test.rb
@@ -4,6 +4,7 @@ class CsvTest < ActiveSupport::TestCase
   include Rack::Test::Methods
   include TestHelpers::AuthHelper
   include TestHelpers::JsonHelper
+  include TestHelpers::TestFileHelper
 
   def app
     Rails.application
@@ -113,7 +114,7 @@ class CsvTest < ActiveSupport::TestCase
 
     data_to_post = {
       unit_id: '1',
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Tasks.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Tasks.csv'),
       auth_token: auth_token
     }
 
@@ -130,7 +131,7 @@ class CsvTest < ActiveSupport::TestCase
 
     data_to_post = {
       unit_id: '1',
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Tasks.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Tasks.csv'),
       auth_token: 'incorrect_auth_token'
     }
 
@@ -146,7 +147,7 @@ class CsvTest < ActiveSupport::TestCase
 
     data_to_post = {
       unit_id: '1',
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Tasks.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Tasks.csv'),
       auth_token: ''
     }
 
@@ -162,7 +163,7 @@ class CsvTest < ActiveSupport::TestCase
 
     data_to_post = {
       unit_id: 'string',
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Tasks.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Tasks.csv'),
       auth_token: auth_token
     }
 
@@ -178,7 +179,7 @@ class CsvTest < ActiveSupport::TestCase
 
     data_to_post = {
       unit_id: '',
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Tasks.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Tasks.csv'),
       auth_token: auth_token
     }
 
@@ -196,7 +197,7 @@ class CsvTest < ActiveSupport::TestCase
 
     data_to_post = {
       unit_id: unit.id,
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Tasks.xlsx'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Tasks.xlsx'),
       auth_token: auth_token
     }
 
@@ -218,7 +219,7 @@ class CsvTest < ActiveSupport::TestCase
 
     data_to_post = {
       unit_id: '1',
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Tasks.pdf'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Tasks.pdf'),
       auth_token: auth_token
     }
 
@@ -250,7 +251,7 @@ class CsvTest < ActiveSupport::TestCase
 
     data_to_post = {
       unit_id: '9999',
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Tasks.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Tasks.csv'),
       auth_token: auth_token
     }
 
@@ -343,7 +344,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '1'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: auth_token
     }
 
@@ -363,7 +364,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '1'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: "incorrect_auth_code"
     }
 
@@ -380,7 +381,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '1'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: ''
     }
 
@@ -397,7 +398,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = 'string'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: auth_token
     }
 
@@ -414,7 +415,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '1'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.pdf'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.pdf'),
       auth_token: auth_token
     }
 
@@ -448,7 +449,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '999'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: auth_token
     }
 
@@ -470,7 +471,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '1'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: auth_token
     }
 
@@ -494,7 +495,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '1'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: 'incorrect_auth_token'
     }
 
@@ -519,7 +520,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '1'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: ''
     }
 
@@ -544,7 +545,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = 'string'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: auth_token
     }
 
@@ -569,7 +570,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = ''
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: auth_token
     }
 
@@ -594,7 +595,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '1'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.xlsx'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.xlsx'),
       auth_token: auth_token
     }
 
@@ -618,7 +619,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '1'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.pdf'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.pdf'),
       auth_token: auth_token
     }
 
@@ -668,7 +669,7 @@ class CsvTest < ActiveSupport::TestCase
 
     unit_id_to_test = '999'
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/COS10001-Students.csv'),
+      file: upload_file_csv('test_files/csv_test_files/COS10001-Students.csv'),
       auth_token: auth_token
     }
 
@@ -913,7 +914,7 @@ class CsvTest < ActiveSupport::TestCase
   def test_csv_upload_users
 
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/doubtfire_users.csv'),
+      file: upload_file_csv('test_files/csv_test_files/doubtfire_users.csv'),
       auth_token: auth_token
   }
 
@@ -930,7 +931,7 @@ class CsvTest < ActiveSupport::TestCase
   def test_csv_upload_users_incorrect_auth_token
 
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/doubtfire_users.csv'),
+      file: upload_file_csv('test_files/csv_test_files/doubtfire_users.csv'),
       auth_token: 'incorrect_auth_token'
   }
 
@@ -946,7 +947,7 @@ class CsvTest < ActiveSupport::TestCase
   def test_csv_upload_users_empty_auth_token
 
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/doubtfire_users.csv'),
+      file: upload_file_csv('test_files/csv_test_files/doubtfire_users.csv'),
       auth_token: ''
   }
 
@@ -962,7 +963,7 @@ class CsvTest < ActiveSupport::TestCase
   def test_csv_upload_users_xlsx
 
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/doubtfire_users.xlsx'),
+      file: upload_file_csv('test_files/csv_test_files/doubtfire_users.xlsx'),
       auth_token: auth_token
   }
 
@@ -979,7 +980,7 @@ class CsvTest < ActiveSupport::TestCase
   def test_csv_upload_users_incorrect_file_pdf
 
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/csv_test_files/doubtfire_users.pdf'),
+      file: upload_file_csv('test_files/csv_test_files/doubtfire_users.pdf'),
       auth_token: auth_token
   }
 

--- a/test/api/groups_test.rb
+++ b/test/api/groups_test.rb
@@ -149,7 +149,7 @@ class GroupsTest < ActiveSupport::TestCase
 
     project = unit.projects.first
 
-    comment_data = { attachment: Rack::Test::UploadedFile.new('test_files/submissions/00_question.pdf', 'application/pdf') }
+    comment_data = { attachment: upload_file('test_files/submissions/00_question.pdf', 'application/pdf') }
 
     post with_auth_token("/api/projects/#{project.id}/task_def_id/#{td.id}/comments", project.student), comment_data
 
@@ -189,7 +189,7 @@ class GroupsTest < ActiveSupport::TestCase
 
     project = unit.projects.first
 
-    comment_data = { attachment: Rack::Test::UploadedFile.new('test_files/submissions/00_question.pdf', 'application/pdf') }
+    comment_data = { attachment: upload_file('test_files/submissions/00_question.pdf', 'application/pdf') }
 
     post with_auth_token("/api/projects/#{project.id}/task_def_id/#{td.id}/comments", project.student), comment_data
 

--- a/test/api/units/task_definitions_test.rb
+++ b/test/api/units/task_definitions_test.rb
@@ -28,7 +28,7 @@ class TaskDefinitionsTest < ActiveSupport::TestCase
     test_task_definition = TaskDefinition.first
 
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/submissions/00_question.pdf', 'application/pdf')
+      file: upload_file('test_files/submissions/00_question.pdf', 'application/pdf')
     }
 
     post "/api/units/#{test_unit.id}/task_definitions/#{test_task_definition.id}/task_sheet", with_auth_token(data_to_post)
@@ -36,7 +36,7 @@ class TaskDefinitionsTest < ActiveSupport::TestCase
     assert_equal 201, last_response.status
     assert test_task_definition.task_sheet
 
-    assert_equal File.size('test_files/submissions/00_question.pdf'), File.size(TaskDefinition.first.task_sheet)
+    assert_equal File.size(data_to_post[:file]), File.size(TaskDefinition.first.task_sheet)
   end
 
   def test_post_task_resources
@@ -44,7 +44,7 @@ class TaskDefinitionsTest < ActiveSupport::TestCase
     test_task_definition_id = TaskDefinition.first.id
 
     data_to_post = {
-      file: Rack::Test::UploadedFile.new('test_files/2015-08-06-COS10001-acain.zip', 'application/zip')
+      file: upload_file('test_files/2015-08-06-COS10001-acain.zip', 'application/zip')
     }
     post "/api/units/#{test_unit_id}/task_definitions/#{test_task_definition_id}/task_resources", with_auth_token(data_to_post)
 

--- a/test/helpers/test_file_helper.rb
+++ b/test/helpers/test_file_helper.rb
@@ -17,5 +17,14 @@ module TestHelpers
     def with_file(path, type, hash)
       with_files( [ {path: path, type: type} ], hash)
     end
+
+    def upload_file_csv(path)
+      Rack::Test::UploadedFile.new(Rails.root.join(path))
+    end
+
+    def upload_file(path, type)
+      Rack::Test::UploadedFile.new(Rails.root.join(path), type)
+    end
+
   end
 end

--- a/test/models/file_helper_test.rb
+++ b/test/models/file_helper_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class FileHelperTest < ActiveSupport::TestCase
   def test_convert_use_with_gif
-    in_file = 'test_files/submissions/unbelievable.gif'
+    in_file = "#{Rails.root}/test_files/submissions/unbelievable.gif"
 
     Dir.mktmpdir do |dir|
       dest_file = "#{dir}#{File.basename(in_file, ".*")}.jpg"


### PR DESCRIPTION
# Description

Add two helpers which allow to get the full path of csv files and other file types and make sure all test file paths are from root

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
