### PR TITLE
FIX: Ensure the last group num is the actual highest value

### DIFF
--- a/app/api/group_sets_api.rb
+++ b/app/api/group_sets_api.rb
@@ -209,8 +209,7 @@ module Api
         error!({error: "You are already in a group for #{group_set.name}"}, 403) unless project.group_for_groupset(group_set).nil?
       end
 
-      last = group_set.groups.last
-      num = last.nil? ? 1 : last.number + 1
+      num = group_set.groups.any? ? group_set.groups.max_by {|g| g.number}.number + 1 : 1
       if group_params[:name].nil? || group_params[:name].empty?
         group_params[:name] = "Group #{num}"
       end


### PR DESCRIPTION
# Description

When posting a new group, if a higher group num is not the last group, the num will be invalid. This PR ensures the new num is the highest num + 1, not the last num.


Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All tests pass. Tested on frontend.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if appropriate
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

If you have any questions, please contact @macite or @jakerenzella.
