### PR TITLE
FIX: Restart postgres after Linux installation via setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -166,6 +166,8 @@ install_postgres () {
                         postgresql-contrib \
                         libpq-dev
 
+        sudo service postgresql restart
+
         msg "Ensure pg_config is on the PATH, and then login to Postgres. You will need to locate where `apt-get` has Installed your Postgres binary and add this to your PATH. You can use: whereis psql for that, but ensure you add the directory and not the executable to the path"
         read -p "Press enter to continue"
 


### PR DESCRIPTION
# Description

Please refer to the commit https://github.com/doubtfire-lms/doubtfire-api/commit/9dec0bf6d1c770f625a174c4ac1ba50db7ae1ee8 which changes `setup.sh` to restart Postgres after installation on Linux, preventing a database connectivity issue during the user & database creation that follows.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Re-installed `doubtfire-api` on a fresh installation of WSL's Ubuntu distribution via `setup.sh`—we didn't run into the database connectivity error.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
