### PR TITLE
NEW: Create task inbox pin

### DIFF
--- a/app/api/units_api.rb
+++ b/app/api/units_api.rb
@@ -202,6 +202,30 @@ module Api
       unit.tasks_as_hash(tasks)
     end
 
+    desc 'Pin a task within the task inbox'
+    put '/units/:unit_id/tasks/:task_id/pin' do
+      unit = Unit.find(params[:unit_id])
+      task = Task.find(params[:task_id])
+
+      unless authorise? current_user, unit, :provide_feedback
+        error!({ error: 'Not authorised to pin task' }, 403) 
+      end
+
+      TaskPin.find_or_create_by(task: task, user: current_user)
+    end
+
+    desc 'Unpin a task within the task inbox'
+    delete '/units/:unit_id/tasks/:task_id/pin' do
+      unit = Unit.find(params[:unit_id])
+      task = Task.find(params[:task_id])
+      
+      unless authorise? current_user, unit, :provide_feedback
+        error!({ error: 'Not authorised to unpin task' }, 403) 
+      end
+
+      TaskPin.find_by(task: task, user: current_user).try(:destroy)
+    end
+
     desc 'Download the tasks that should be listed under the task inbox'
     get '/units/:id/tasks/inbox' do
       unit = Unit.find(params[:id])

--- a/app/models/task_pin.rb
+++ b/app/models/task_pin.rb
@@ -1,0 +1,4 @@
+class TaskPin < ActiveRecord::Base
+  belongs_to :task
+  belongs_to :user
+end

--- a/db/migrate/20200512143828_create_task_pins.rb
+++ b/db/migrate/20200512143828_create_task_pins.rb
@@ -1,0 +1,10 @@
+class CreateTaskPins < ActiveRecord::Migration
+  def change
+    create_table :task_pins do |t|
+      t.integer :task_id
+      t.integer :user_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200327052250) do
+ActiveRecord::Schema.define(version: 20200512143828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -245,6 +245,13 @@ ActiveRecord::Schema.define(version: 20200327052250) do
 
   add_index "task_engagements", ["task_id"], name: "index_task_engagements_on_task_id", using: :btree
 
+  create_table "task_pins", force: :cascade do |t|
+    t.integer  "task_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "task_statuses", force: :cascade do |t|
     t.string   "name",        limit: 255
     t.string   "description", limit: 255
@@ -396,9 +403,7 @@ ActiveRecord::Schema.define(version: 20200327052250) do
     t.string   "last_name",                       limit: 255
     t.string   "username",                        limit: 255
     t.string   "nickname",                        limit: 255
-    t.string   "authentication_token",            limit: 255
     t.string   "unlock_token",                    limit: 255
-    t.datetime "auth_token_expiry"
     t.integer  "role_id",                                     default: 0
     t.boolean  "receive_task_notifications",                  default: true
     t.boolean  "receive_feedback_notifications",              default: true
@@ -407,9 +412,10 @@ ActiveRecord::Schema.define(version: 20200327052250) do
     t.boolean  "has_run_first_time_setup",                    default: false
     t.string   "login_id"
     t.string   "student_id"
+    t.string   "authentication_token",            limit: 255
+    t.datetime "auth_token_expiry"
   end
 
-  add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree
   add_index "users", ["login_id"], name: "index_users_on_login_id", unique: true, using: :btree
 
   add_foreign_key "breaks", "teaching_periods"

--- a/test/factories/task_pins.rb
+++ b/test/factories/task_pins.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :task_pin do
+    task { 1 }
+    user { 1 }
+  end
+end

--- a/test/models/task_pin_test.rb
+++ b/test/models/task_pin_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class TaskPinTest < ActiveSupport::TestCase
+  def task_pin
+    @task_pin ||= TaskPin.new
+  end
+
+  def test_valid
+    assert task_pin.valid?
+  end
+end


### PR DESCRIPTION
# Description

At the request of Jake Renzella, this Pull Request creates the 'task pin' feature, which creates the API interface to allow pinning of tasks from the task inbox. Corresponding record retrieval methods (both model and query) have been updated to reflect if a task has been pinned, with records first sorted by 'pinned'.

Fixes # Tasks disappearing from task inbox

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested API PUT and DELETE methods using the Swagger interface, with corresponding verification through direct query of the database. Authenticated with two users (acain, aconvenor) to view the task inbox, after having queued changes through student accounts 1-3. Tested various permutations of pinning/unpinning the various tasks to visually confirm that each displays correctly.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation if appropriate
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have created or extended unit tests to address my new additions
- [] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

If you have any questions, please contact @macite or @jakerenzella.
