### PR TITLE
NEW: Allow exporting task dates in iCalendar format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,4 +77,7 @@ gem 'dotenv-rails'
 gem 'roo', '~> 2.7.0'
 gem 'roo-xls'
 
+# webcal generation
+gem 'icalendar', '~> 2.5', '>= 2.5.3'
+
 gem 'rest-client', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,9 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    icalendar (2.5.3)
+      ice_cube (~> 0.16)
+    ice_cube (0.16.3)
     ice_nine (0.11.2)
     json (1.8.3)
     json-jwt (1.7.0)
@@ -286,6 +289,7 @@ DEPENDENCIES
   grape-active_model_serializers (~> 1.3.2)
   grape-swagger
   hirb
+  icalendar (~> 2.5, >= 2.5.3)
   json-jwt (= 1.7.0)
   minitest-around
   minitest-rails

--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -60,6 +60,7 @@ module Api
     mount Api::UnitRolesApi
     mount Api::UnitsApi
     mount Api::UsersApi
+    mount Api::WebcalApi
 
     #
     # Add auth details to all end points

--- a/app/api/webcal_api.rb
+++ b/app/api/webcal_api.rb
@@ -81,7 +81,8 @@ module Api
             projects: { user_id: webcal.user_id },
             units: { active: true }
           )
-          .where('? BETWEEN units.start_date AND units.end_date', Time.zone.now)
+          .where('tasks.project_id is null or tasks.project_id = projects.id')   # eager_load(:tasks) only tasks of :projects
+          .where('? BETWEEN units.start_date AND units.end_date', Time.zone.now) # Current units
       )
 
       # Specify refresh interval.

--- a/app/api/webcal_api.rb
+++ b/app/api/webcal_api.rb
@@ -21,9 +21,10 @@ module Api
     desc 'Update webcal details of the authenticated user'
     params do
       requires :webcal, type: Hash do
-        optional :enabled,             type: Boolean, desc: 'Is the webcal enabled?'
-        optional :should_change_guid,  type: Boolean, desc: 'Should the GUID of the webcal be changed?'
-        optional :include_start_dates, type: Boolean, desc: 'Should events for start dates be included?'
+        optional :enabled,             type: Boolean,        desc: 'Is the webcal enabled?'
+        optional :should_change_guid,  type: Boolean,        desc: 'Should the GUID of the webcal be changed?'
+        optional :include_start_dates, type: Boolean,        desc: 'Should events for start dates be included?'
+        optional :unit_exclusions,     type: Array[Integer], desc: 'IDs of units that must be excluded from the webcal'
       end
       requires :auth_token, type: String, desc: 'Authentication token'
     end
@@ -32,7 +33,12 @@ module Api
       webcal_params = params[:webcal]
 
       user = current_user
-      cal = user.webcal
+
+      cal = Webcal
+        .includes(:webcal_unit_exclusions)
+        .where(user_id: user.id)
+        .load
+        .first
 
       # Create or destroy the user's webcal, according to the `enabled` parameter.
       if webcal_params.key?(:enabled)
@@ -56,8 +62,30 @@ module Api
         :include_start_dates
       )
 
-      # Update and return calendar.
+      # Update calendar.
       cal.update! webcal_update_params
+
+      # Update unit exclusions, if specified.
+      if webcal_params.key?(:unit_exclusions)
+
+        # Delete existing exclusions.
+        cal.webcal_unit_exclusions.delete_all
+
+        # Add exclusions with valid unit IDs.
+        if webcal_params[:unit_exclusions].any?
+          cal.webcal_unit_exclusions.create(
+            Unit
+              .joins(:projects)
+              .where(
+                projects: { user_id: 7 },
+                units: { id: webcal_params[:unit_exclusions], active: true }
+              )
+              .pluck(:id)
+              .map { |i| { unit_id: i } }
+          )
+        end
+      end
+
       cal
     end
 
@@ -68,8 +96,7 @@ module Api
     get '/webcal/:guid' do
 
       # Retrieve the specified webcal.
-      webcal = Webcal.where(guid: params[:guid]).first
-      return error!({ error: 'Unable to find the requested webcal.' }, 404) if webcal.nil?
+      webcal = Webcal.where(guid: params[:guid]).first!
 
       # Generate iCalendar.
       ical = webcal.to_ical_with_task_definitions(
@@ -81,6 +108,9 @@ module Api
           .where(
             projects: { user_id: webcal.user_id },
             units: { active: true }
+          )
+          .where.not(
+            units: { id: WebcalUnitExclusion.where(webcal_id: webcal.id).select(:unit_id) } # exclude :webcal_unit_exclusions
           )
           .where('tasks.project_id is null or tasks.project_id = projects.id')   # eager_load only :tasks of :projects
           .where('? BETWEEN units.start_date AND units.end_date', Time.zone.now) # Current units

--- a/app/api/webcal_api.rb
+++ b/app/api/webcal_api.rb
@@ -1,0 +1,31 @@
+require 'grape'
+
+module Api
+
+  class WebcalApi < Grape::API
+
+    desc 'Serves web calendars ("webcals") that include the target/extension dates of all tasks of students\' active units.'
+    params do
+      requires :id, type: String, desc: 'The ID of the webcal'
+    end
+    get '/webcal/:id' do
+      # Retrieve the specified webcal.
+      webcal = Webcal.find(params[:id])
+      task_definitions = []
+
+      # Retrieve task definitions and tasks of the user's active units.
+      # TODO: Can this be reduced to 1 query instead of 1 + # of projects?
+      webcal.user.projects
+        .joins(:unit)
+        .where(units: { active: true })
+        .each do |prj|
+          prj.unit.task_definitions.includes(:tasks).where(tasks: { project_id: [prj.id, nil] }).each do |td|
+            task_definitions.push(td)
+          end
+        end
+
+      task_definitions
+    end
+
+  end
+end

--- a/app/api/webcal_api.rb
+++ b/app/api/webcal_api.rb
@@ -72,7 +72,7 @@ module Api
 
       # Generate iCalendar.
       ical = webcal.to_ical_with_task_definitions(
-        # Retrieve task definitions and tasks of the user's active units.
+        # Retrieve task definitions and tasks of the user's current active units.
         TaskDefinition
           .joins(:unit, unit: :projects)
           .eager_load(:tasks)
@@ -81,6 +81,7 @@ module Api
             projects: { user_id: webcal.user_id },
             units: { active: true }
           )
+          .where('? BETWEEN units.start_date AND units.end_date', Time.zone.now)
       )
 
       # Specify refresh interval.

--- a/app/api/webcal_api.rb
+++ b/app/api/webcal_api.rb
@@ -1,4 +1,5 @@
 require 'grape'
+require 'icalendar'
 
 module Api
 
@@ -9,9 +10,10 @@ module Api
       requires :id, type: String, desc: 'The ID of the webcal'
     end
     get '/webcal/:id' do
+
       # Retrieve the specified webcal.
       webcal = Webcal.find(params[:id])
-      task_definitions = []
+      ical = Icalendar::Calendar.new
 
       # Retrieve task definitions and tasks of the user's active units.
       # TODO: Can this be reduced to 1 query instead of 1 + # of projects?
@@ -20,11 +22,21 @@ module Api
         .where(units: { active: true })
         .each do |prj|
           prj.unit.task_definitions.includes(:tasks).where(tasks: { project_id: [prj.id, nil] }).each do |td|
-            task_definitions.push(td)
-          end
-        end
 
-      task_definitions
+            # Add the task to the iCalendar.
+            ical.event do |ev|
+              ev.summary = "#{td.unit.code}: #{td.abbreviation}: #{td.name}"
+              # The start and end dates should be equal because the calendar event is expected to be an "all-day" event.
+              ev.dtstart = Icalendar::Values::Date.new(td.target_date.strftime('%Y%m%d'))
+              ev.dtend = Icalendar::Values::Date.new(td.target_date.strftime('%Y%m%d'))
+            end
+
+          end
+      end
+
+      # Serve the iCalendar with the correct MIME type.
+      content_type 'text/calendar'
+      ical.to_ical
     end
 
   end

--- a/app/api/webcal_api.rb
+++ b/app/api/webcal_api.rb
@@ -4,9 +4,64 @@ require 'icalendar'
 module Api
 
   class WebcalApi < Grape::API
+    helpers AuthenticationHelpers
+
+    # Declare content types
     content_type :txt, 'text/calendar'
 
-    desc 'Serves web calendars ("webcals") that include selected dates of tasks of students\' active units.'
+    desc 'Get webcal details of the authenticated user'
+    params do
+      requires :auth_token, type: String, desc: 'Authentication token'
+    end
+    get '/webcal' do
+      authenticated?
+      current_user.webcal
+    end
+
+    desc 'Update webcal details of the authenticated user'
+    params do
+      requires :webcal, type: Hash do
+        optional :enabled,             type: Boolean, desc: 'Is the webcal enabled?'
+        optional :should_change_id,    type: Boolean, desc: 'Should the ID of the webcal be changed?'
+        optional :include_start_dates, type: Boolean, desc: 'Should events for start dates be included?'
+      end
+      requires :auth_token, type: String, desc: 'Authentication token'
+    end
+    put '/webcal' do
+      authenticated?
+      webcal_params = params[:webcal]
+
+      user = current_user
+      cal = user.webcal
+
+      # Create or destroy the user's webcal, according to the `enabled` parameter.
+      if webcal_params.key?(:enabled)
+        if webcal_params[:enabled] and cal == nil
+          cal = user.create_webcal(id: SecureRandom.uuid)
+        elsif (not webcal_params[:enabled]) and cal != nil
+          cal.destroy
+        end
+      end
+
+      return if cal == nil or cal.destroyed?
+      webcal_update_params = {}
+
+      # Change the ID if requested.
+      if webcal_params.key?(:should_change_id)
+        webcal_update_params[:id] = SecureRandom.uuid
+      end
+
+      # Set any other properties that have to be updated verbatim.
+      webcal_update_params.merge! ActionController::Parameters.new(webcal_params).permit(
+        :include_start_dates
+      )
+
+      # Update and return calendar.
+      cal.update! webcal_update_params
+      cal
+    end
+
+    desc 'Serve webcal with the specified ID'
     params do
       requires :id, type: String, desc: 'The ID of the webcal'
     end

--- a/app/api/webcal_api.rb
+++ b/app/api/webcal_api.rb
@@ -71,6 +71,15 @@ module Api
       webcal = Webcal.find(params[:id])
       ical = Icalendar::Calendar.new
 
+      # Specify refresh interval.
+      refresh_interval = Icalendar::Values::Duration.new('1D')
+
+      # https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcical/1fc7b244-ecd1-4d28-ac0c-2bb4df855a1f
+      ical.append_custom_property('X-PUBLISHED-TTL', refresh_interval)
+
+      # https://tools.ietf.org/html/rfc7986#section-5.7
+      ical.append_custom_property('REFRESH-INTERVAL', refresh_interval)
+
       # Retrieve task definitions and tasks of the user's active units.
       TaskDefinition
           .eager_load(:tasks)
@@ -95,7 +104,7 @@ module Api
             # Add event for target/extended date.
             # TODO: Use extension date if available.
             ical.event do |ev|
-              ev.summary = "#{webcal.include_start_dates ? "End:" : ""}#{ev_name}"
+              ev.summary = "#{webcal.include_start_dates ? 'End:' : ''}#{ev_name}"
               ev.dtstart = ev.dtend = Icalendar::Values::Date.new(td.target_date.strftime('%Y%m%d'))
             end
 

--- a/app/api/webcal_api.rb
+++ b/app/api/webcal_api.rb
@@ -81,8 +81,9 @@ module Api
             projects: { user_id: webcal.user_id },
             units: { active: true }
           )
-          .where('tasks.project_id is null or tasks.project_id = projects.id')   # eager_load(:tasks) only tasks of :projects
+          .where('tasks.project_id is null or tasks.project_id = projects.id')   # eager_load only :tasks of :projects
           .where('? BETWEEN units.start_date AND units.end_date', Time.zone.now) # Current units
+          .where('task_definitions.target_grade <= projects.target_grade')       # only :tasks of the targeted_grade or lower
       )
 
       # Specify refresh interval.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -170,7 +170,7 @@ class User < ActiveRecord::Base
   belongs_to  :role # Foreign Key
   has_many    :unit_roles, dependent: :destroy
   has_many    :projects
-  has_one     :webcal
+  has_one     :webcal, dependent: :destroy
 
   # Model validations/constraints
   validates :first_name,  presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -170,6 +170,7 @@ class User < ActiveRecord::Base
   belongs_to  :role # Foreign Key
   has_many    :unit_roles, dependent: :destroy
   has_many    :projects
+  has_one     :webcal
 
   # Model validations/constraints
   validates :first_name,  presence: true

--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -27,13 +27,14 @@ class Webcal < ActiveRecord::Base
       #   ID prefixed with S- or E- based on whether it is a start or end event.
 
       ev_name = "#{td.unit.code}: #{td.abbreviation}: #{td.name}"
+      ev_date_format = '%Y%m%d'
 
       # Add event for start date, if the user opted in.
       if include_start_dates
         ical.event do |ev|
           ev.uid = "S-#{td.id}"
           ev.summary = "Start: #{ev_name}"
-          ev.dtstart = ev.dtend = Icalendar::Values::Date.new(td.start_date.strftime('%Y%m%d'))
+          ev.dtstart = ev.dtend = Icalendar::Values::Date.new(td.start_date.strftime(ev_date_format))
         end
       end
 
@@ -44,7 +45,7 @@ class Webcal < ActiveRecord::Base
 
         ev_date = td.target_date
         ev_date += (td.tasks.first.extensions * 7).day if td.tasks.present?
-        ev.dtstart = ev.dtend = Icalendar::Values::Date.new(ev_date.strftime('%Y%m%d'))
+        ev.dtstart = ev.dtend = Icalendar::Values::Date.new(ev_date.strftime(ev_date_format))
       end
     end
 

--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -1,0 +1,3 @@
+class Webcal < ActiveRecord::Base
+  belongs_to :user
+end

--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -38,11 +38,13 @@ class Webcal < ActiveRecord::Base
       end
 
       # Add event for target/extended date.
-      # TODO: Use extension date if available.
       ical.event do |ev|
         ev.uid = "E-#{td.id}"
         ev.summary = "#{include_start_dates ? 'End:' : ''}#{ev_name}"
-        ev.dtstart = ev.dtend = Icalendar::Values::Date.new(td.target_date.strftime('%Y%m%d'))
+
+        ev_date = td.target_date
+        ev_date += (td.tasks.first.extensions * 7).day if td.tasks.present?
+        ev.dtstart = ev.dtend = Icalendar::Values::Date.new(ev_date.strftime('%Y%m%d'))
       end
     end
 

--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -1,6 +1,11 @@
 require 'icalendar'
 
 class Webcal < ActiveRecord::Base
+
+  # Explicitly define the primary key here because it isn't defined in the Rails migration.
+  # Refer to the migration 20200817020024_create_webcals.rb for more information.
+  self.primary_key = :id
+
   belongs_to :user
 
   #

--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -2,10 +2,6 @@ require 'icalendar'
 
 class Webcal < ActiveRecord::Base
 
-  # Explicitly define the primary key here because it isn't defined in the Rails migration.
-  # Refer to the migration 20200817020024_create_webcals.rb for more information.
-  self.primary_key = :id
-
   belongs_to :user
 
   #

--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -35,6 +35,7 @@ class Webcal < ActiveRecord::Base
   #
   def to_ical_with_task_definitions(defs = [])
     ical = Icalendar::Calendar.new
+    ical.publish
     ical.prodid = Doubtfire::Application.config.institution[:product_name]
 
     # Add iCalendar events for the specified definition.
@@ -56,6 +57,7 @@ class Webcal < ActiveRecord::Base
 
           ev.uid = "S-#{td.id}"
           ev.summary = ev_summary
+          ev.status = 'CONFIRMED'
           ev.dtstart = ev.dtend = Icalendar::Values::Date.new(td.start_date.strftime(ev_date_format))
 
           if ev_reminders
@@ -84,6 +86,7 @@ class Webcal < ActiveRecord::Base
           ev.alarm do |a|
             a.action = 'DISPLAY'
             a.description = ev_summary
+            ev.status = 'CONFIRMED'
             a.trigger = ev_reminder_trigger
           end
         end

--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -4,6 +4,8 @@ class Webcal < ActiveRecord::Base
 
   belongs_to :user
 
+  has_many :webcal_unit_exclusions, dependent: :destroy
+
   #
   # Generates a single `Icalendar::Calendar` object from this `Webcal` including calendar events for the specified
   # collection of `TaskDefinition`s.

--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -7,6 +7,21 @@ class Webcal < ActiveRecord::Base
   has_many :webcal_unit_exclusions, dependent: :destroy
 
   #
+  # Array of valid units by which task reminders (alarms) can be set.
+  # Documented at https://tools.ietf.org/html/rfc5545#section-3.3.6
+  #
+  def self.valid_time_units
+    %w(W D H M)
+  end
+
+  #
+  # Represents the presence of `reminder_time` and `reminder_unit`.
+  #
+  def reminder?
+    reminder_time.present? && reminder_unit.present?
+  end
+
+  #
   # Generates a single `Icalendar::Calendar` object from this `Webcal` including calendar events for the specified
   # collection of `TaskDefinition`s.
   #
@@ -31,24 +46,47 @@ class Webcal < ActiveRecord::Base
 
       ev_name = "#{td.unit.code}: #{td.abbreviation}: #{td.name}"
       ev_date_format = '%Y%m%d'
+      ev_reminders = reminder?
+      ev_reminder_trigger = "-PT#{reminder_time}#{reminder_unit}"
 
       # Add event for start date, if the user opted in.
       if include_start_dates
         ical.event do |ev|
+          ev_summary = "Start: #{ev_name}"
+
           ev.uid = "S-#{td.id}"
-          ev.summary = "Start: #{ev_name}"
+          ev.summary = ev_summary
           ev.dtstart = ev.dtend = Icalendar::Values::Date.new(td.start_date.strftime(ev_date_format))
+
+          if ev_reminders
+            ev.alarm do |a|
+              a.action = 'DISPLAY'
+              a.description = ev_summary
+              a.trigger = ev_reminder_trigger
+            end
+          end
         end
       end
 
       # Add event for target/extended date.
       ical.event do |ev|
-        ev.uid = "E-#{td.id}"
-        ev.summary = "#{include_start_dates ? 'End:' : ''}#{ev_name}"
+        ev_summary = "#{include_start_dates ? 'End:' : ''}#{ev_name}"
 
+        ev.uid = "E-#{td.id}"
+        ev.summary = ev_summary
+
+        # Use extended date if available.
         ev_date = td.target_date
         ev_date += (td.tasks.first.extensions * 7).day if td.tasks.present?
         ev.dtstart = ev.dtend = Icalendar::Values::Date.new(ev_date.strftime(ev_date_format))
+
+        if ev_reminders
+          ev.alarm do |a|
+            a.action = 'DISPLAY'
+            a.description = ev_summary
+            a.trigger = ev_reminder_trigger
+          end
+        end
       end
     end
 

--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -1,3 +1,45 @@
+require 'icalendar'
+
 class Webcal < ActiveRecord::Base
   belongs_to :user
+
+  #
+  # Generates a single `Icalendar::Calendar` object from this `Webcal` including calendar events for the specified
+  # collection of `TaskDefinition`s.
+  #
+  # The `unit` property of each `TaskDefinition` is accessed; ensure it is included to prevent N+1 selects. For example,
+  #
+  #   to_ical_with_task_definitions(
+  #     TaskDefinition
+  #       .joins(:unit)
+  #       .includes(:unit)
+  #   )
+  #
+  def to_ical_with_task_definitions(defs = [])
+    ical = Icalendar::Calendar.new
+
+    # Add iCalendar events for the specified definition.
+    defs.each  do |td|
+      # Note: Start and end dates of events are equal because the calendar event is expected to be an "all-day" event.
+
+      ev_name = "#{td.unit.code}: #{td.abbreviation}: #{td.name}"
+
+      # Add event for start date, if the user opted in.
+      if include_start_dates
+        ical.event do |ev|
+          ev.summary = "Start: #{ev_name}"
+          ev.dtstart = ev.dtend = Icalendar::Values::Date.new(td.start_date.strftime('%Y%m%d'))
+        end
+      end
+
+      # Add event for target/extended date.
+      # TODO: Use extension date if available.
+      ical.event do |ev|
+        ev.summary = "#{include_start_dates ? 'End:' : ''}#{ev_name}"
+        ev.dtstart = ev.dtend = Icalendar::Values::Date.new(td.target_date.strftime('%Y%m%d'))
+      end
+    end
+
+    ical
+  end
 end

--- a/app/models/webcal_unit_exclusion.rb
+++ b/app/models/webcal_unit_exclusion.rb
@@ -1,0 +1,4 @@
+class WebcalUnitExclusion < ActiveRecord::Base
+  belongs_to :webcal
+  belongs_to :unit
+end

--- a/app/serializers/webcal_serializer.rb
+++ b/app/serializers/webcal_serializer.rb
@@ -1,0 +1,7 @@
+class WebcalSerializer < ActiveModel::Serializer
+  attributes :id, :guid, :include_start_dates, :unit_exclusions
+
+  def unit_exclusions
+    object.webcal_unit_exclusions.map(&:unit_id)
+  end
+end

--- a/app/serializers/webcal_serializer.rb
+++ b/app/serializers/webcal_serializer.rb
@@ -1,5 +1,16 @@
 class WebcalSerializer < ActiveModel::Serializer
-  attributes :id, :guid, :include_start_dates, :unit_exclusions
+  attributes :id, :guid, :include_start_dates, :reminder, :unit_exclusions
+
+  def reminder
+    if object.reminder_time.nil? || object.reminder_unit.nil?
+      nil
+    else
+      {
+        time: object.reminder_time,
+        unit: object.reminder_unit
+      }
+    end
+  end
 
   def unit_exclusions
     object.webcal_unit_exclusions.map(&:unit_id)

--- a/db/migrate/20200817020024_create_webcals.rb
+++ b/db/migrate/20200817020024_create_webcals.rb
@@ -1,0 +1,8 @@
+class CreateWebcals < ActiveRecord::Migration
+  def change
+    create_table(:webcals, id: :string) do |t|
+      t.boolean    :include_start_dates, null: false, default: false
+      t.references :user, foreign_key: true, index: { unique: true }
+    end
+  end
+end

--- a/db/migrate/20200817020024_create_webcals.rb
+++ b/db/migrate/20200817020024_create_webcals.rb
@@ -1,10 +1,9 @@
 class CreateWebcals < ActiveRecord::Migration
   def change
-    create_table(:webcals, id: false) do |t|
+    create_table :webcals do |t|
 
-      # Expected to be a 36 character GUID (string). Not defined as a primary key here because Rails doesn't dump the
-      # definition of the primary key to schema.rb even when the type is explicitly specified via create_table.
-      t.string     :id, null: false, limit: 36, index: { unique: true }
+      # Expected to be a 36 character GUID (string).
+      t.string     :guid, null: false, limit: 36, index: { unique: true }
 
       t.boolean    :include_start_dates, null: false, default: false
       t.references :user, foreign_key: true, index: { unique: true }

--- a/db/migrate/20200817020024_create_webcals.rb
+++ b/db/migrate/20200817020024_create_webcals.rb
@@ -1,6 +1,11 @@
 class CreateWebcals < ActiveRecord::Migration
   def change
-    create_table(:webcals, id: :string) do |t|
+    create_table(:webcals, id: false) do |t|
+
+      # Expected to be a 36 character GUID (string). Not defined as a primary key here because Rails doesn't dump the
+      # definition of the primary key to schema.rb even when the type is explicitly specified via create_table.
+      t.string     :id, null: false, limit: 36, index: { unique: true }
+
       t.boolean    :include_start_dates, null: false, default: false
       t.references :user, foreign_key: true, index: { unique: true }
     end

--- a/db/migrate/20200908115109_create_webcal_unit_exclusions.rb
+++ b/db/migrate/20200908115109_create_webcal_unit_exclusions.rb
@@ -1,7 +1,7 @@
 class CreateWebcalUnitExclusions < ActiveRecord::Migration
   def change
 
-    create_table :webcal_unit_exclusions, id: false do |t|
+    create_table :webcal_unit_exclusions do |t|
       t.references :webcal, foreign_key: true, null: false
       t.references :unit, foreign_key: true, null: false
     end

--- a/db/migrate/20200908115109_create_webcal_unit_exclusions.rb
+++ b/db/migrate/20200908115109_create_webcal_unit_exclusions.rb
@@ -1,0 +1,12 @@
+class CreateWebcalUnitExclusions < ActiveRecord::Migration
+  def change
+
+    create_table :webcal_unit_exclusions, id: false do |t|
+      t.references :webcal, foreign_key: true, null: false
+      t.references :unit, foreign_key: true, null: false
+    end
+
+    add_index :webcal_unit_exclusions, [:unit_id, :webcal_id], { unique: true }
+
+  end
+end

--- a/db/migrate/20200909074930_add_reminders_to_webcal.rb
+++ b/db/migrate/20200909074930_add_reminders_to_webcal.rb
@@ -1,0 +1,6 @@
+class AddRemindersToWebcal < ActiveRecord::Migration
+  def change
+    add_column :webcals, :reminder_time, :integer
+    add_column :webcals, :reminder_unit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -415,7 +415,7 @@ ActiveRecord::Schema.define(version: 20200908115109) do
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree
   add_index "users", ["login_id"], name: "index_users_on_login_id", unique: true, using: :btree
 
-  create_table "webcal_unit_exclusions", id: false, force: :cascade do |t|
+  create_table "webcal_unit_exclusions", force: :cascade do |t|
     t.integer "webcal_id", null: false
     t.integer "unit_id",   null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -415,11 +415,13 @@ ActiveRecord::Schema.define(version: 20200817020024) do
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree
   add_index "users", ["login_id"], name: "index_users_on_login_id", unique: true, using: :btree
 
-  create_table "webcals", force: :cascade do |t|
-    t.boolean "include_start_dates", default: false, null: false
+  create_table "webcals", id: false, force: :cascade do |t|
+    t.string  "id",                  limit: 36,                 null: false
+    t.boolean "include_start_dates",            default: false, null: false
     t.integer "user_id"
   end
 
+  add_index "webcals", ["id"], name: "index_webcals_on_id", unique: true, using: :btree
   add_index "webcals", ["user_id"], name: "index_webcals_on_user_id", unique: true, using: :btree
 
   add_foreign_key "breaks", "teaching_periods"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -415,13 +415,13 @@ ActiveRecord::Schema.define(version: 20200817020024) do
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree
   add_index "users", ["login_id"], name: "index_users_on_login_id", unique: true, using: :btree
 
-  create_table "webcals", id: false, force: :cascade do |t|
-    t.string  "id",                  limit: 36,                 null: false
+  create_table "webcals", force: :cascade do |t|
+    t.string  "guid",                limit: 36,                 null: false
     t.boolean "include_start_dates",            default: false, null: false
     t.integer "user_id"
   end
 
-  add_index "webcals", ["id"], name: "index_webcals_on_id", unique: true, using: :btree
+  add_index "webcals", ["guid"], name: "index_webcals_on_guid", unique: true, using: :btree
   add_index "webcals", ["user_id"], name: "index_webcals_on_user_id", unique: true, using: :btree
 
   add_foreign_key "breaks", "teaching_periods"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200817020024) do
+ActiveRecord::Schema.define(version: 20200908115109) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -415,6 +415,13 @@ ActiveRecord::Schema.define(version: 20200817020024) do
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree
   add_index "users", ["login_id"], name: "index_users_on_login_id", unique: true, using: :btree
 
+  create_table "webcal_unit_exclusions", id: false, force: :cascade do |t|
+    t.integer "webcal_id", null: false
+    t.integer "unit_id",   null: false
+  end
+
+  add_index "webcal_unit_exclusions", ["unit_id", "webcal_id"], name: "index_webcal_unit_exclusions_on_unit_id_and_webcal_id", unique: true, using: :btree
+
   create_table "webcals", force: :cascade do |t|
     t.string  "guid",                limit: 36,                 null: false
     t.boolean "include_start_dates",            default: false, null: false
@@ -437,5 +444,7 @@ ActiveRecord::Schema.define(version: 20200817020024) do
   add_foreign_key "tutorials", "campuses"
   add_foreign_key "tutorials", "tutorial_streams"
   add_foreign_key "units", "teaching_periods"
+  add_foreign_key "webcal_unit_exclusions", "units"
+  add_foreign_key "webcal_unit_exclusions", "webcals"
   add_foreign_key "webcals", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200908115109) do
+ActiveRecord::Schema.define(version: 20200909074930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -426,6 +426,8 @@ ActiveRecord::Schema.define(version: 20200908115109) do
     t.string  "guid",                limit: 36,                 null: false
     t.boolean "include_start_dates",            default: false, null: false
     t.integer "user_id"
+    t.integer "reminder_time"
+    t.string  "reminder_unit"
   end
 
   add_index "webcals", ["guid"], name: "index_webcals_on_guid", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200716054137) do
+ActiveRecord::Schema.define(version: 20200817020024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -415,6 +415,13 @@ ActiveRecord::Schema.define(version: 20200716054137) do
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree
   add_index "users", ["login_id"], name: "index_users_on_login_id", unique: true, using: :btree
 
+  create_table "webcals", force: :cascade do |t|
+    t.boolean "include_start_dates", default: false, null: false
+    t.integer "user_id"
+  end
+
+  add_index "webcals", ["user_id"], name: "index_webcals_on_user_id", unique: true, using: :btree
+
   add_foreign_key "breaks", "teaching_periods"
   add_foreign_key "comments_read_receipts", "task_comments"
   add_foreign_key "comments_read_receipts", "users"
@@ -428,4 +435,5 @@ ActiveRecord::Schema.define(version: 20200716054137) do
   add_foreign_key "tutorials", "campuses"
   add_foreign_key "tutorials", "tutorial_streams"
   add_foreign_key "units", "teaching_periods"
+  add_foreign_key "webcals", "users"
 end

--- a/test/api/webcal_api_test.rb
+++ b/test/api/webcal_api_test.rb
@@ -1,0 +1,102 @@
+require 'test_helper'
+
+class UnitsTest < ActiveSupport::TestCase
+  include Rack::Test::Methods
+  include TestHelpers::AuthHelper
+  include TestHelpers::JsonHelper
+
+  def app
+    Rails.application
+  end
+
+  setup do
+    @student = FactoryBot.create(:user, :student)
+  end
+
+  teardown do
+    @student.destroy
+  end
+
+  test 'Setting enabled creates or destroys webcal' do
+
+    # Enable webcal
+    put_json '/api/webcal', with_auth_token({ webcal: { enabled: true } }, @student)
+
+    # Ensure enabled
+    assert_not_nil Webcal.find_by(user: @student)
+
+    get with_auth_token('/api/webcal', @student)
+    assert_equal 200, last_response.status
+    assert last_response_body['enabled']
+
+    # Disable webcal
+    put_json '/api/webcal', with_auth_token({ webcal: { enabled: false } }, @student)
+
+    # Ensure disabled
+    assert_nil Webcal.find_by(user: @student)
+
+    get with_auth_token('/api/webcal', @student)
+    assert_equal 200, last_response.status
+    assert_not last_response_body['enabled']
+  end
+
+  test 'Enabled with sensible defaults' do
+    # Enable webcal
+    put_json '/api/webcal', with_auth_token({ webcal: { enabled: true } }, @student)
+
+    # Ensure sensible defaults in the database
+    webcal = @student.webcal
+    assert_equal [], webcal.webcal_unit_exclusions
+    assert_not webcal.include_start_dates
+    assert_nil webcal.reminder_time
+    assert_nil webcal.reminder_unit
+  end
+
+  test 'should_change_guid changes guid' do
+
+    # Create webcal, get GUID
+    prev_guid = @student.create_webcal(guid: SecureRandom.uuid).guid
+
+    # Request GUID change
+    put_json '/api/webcal', with_auth_token({ webcal: { should_change_guid: true } }, @student)
+    current_guid = @student.webcal.reload.guid
+
+    # Ensure GUID changed
+    assert_not_equal prev_guid, current_guid
+    get with_auth_token('/api/webcal', @student)
+    assert_equal current_guid, last_response_body['guid']
+  end
+
+  test 'Ical endpoint is public and serves webcal with corect content type' do
+    # Create webcal
+    webcal = @student.create_webcal(guid: SecureRandom.uuid)
+
+    # Retrieve ical _without auth_
+    get "/api/webcal/#{webcal.guid}"
+
+    # Ensure correct content type
+    assert_equal 200, last_response.status
+    assert_equal 'text/calendar', last_response['Content-Type']
+  end
+
+  test 'Reminder must be specified with both time & unit' do
+    # Create webcal
+    webcal = @student.create_webcal(guid: SecureRandom.uuid)
+
+    # Specify only time
+    put_json '/api/webcal', with_auth_token({ webcal: { reminder: { time: 5 } } }, @student)
+    assert 400, last_response.status
+
+    # Specify only unit
+    put_json '/api/webcal', with_auth_token({ webcal: { reminder: { unit: 'D' } } }, @student)
+    assert 400, last_response.status
+
+    # Specify both time & unit
+    put_json '/api/webcal', with_auth_token({ webcal: { reminder: { time: 5, unit: 'D' } } }, @student)
+    assert 200, last_response.status
+
+    webcal.reload
+    assert_equal 5, webcal.reminder_time
+    assert_equal 'D', webcal.reminder_unit
+  end
+end

--- a/test/models/webcal_test.rb
+++ b/test/models/webcal_test.rb
@@ -1,0 +1,131 @@
+require 'test_helper'
+
+class WebcalTest < ActiveSupport::TestCase
+  setup do
+    # Create student
+    @student = FactoryBot.create(:user, :student)
+    @campus = FactoryBot.create(:campus)
+
+    # Create ongoing units
+    @current_unit_1 = FactoryBot.create(:unit, task_count: 10)
+    @current_unit_1.enrol_student(@student, @campus)
+    @current_project_1 = Project.find_by(user: @student, unit: @current_unit_1)
+    @current_project_1.update(target_grade: 3)
+
+    @current_unit_2 = FactoryBot.create(:unit, task_count: 10)
+    @current_unit_2.enrol_student(@student, @campus)
+    @current_project_2 = Project.find_by(user: @student, unit: @current_unit_2)
+    @current_project_2.update(target_grade: 3)
+
+    # Create old unit
+    @old_unit = FactoryBot.create(:unit, task_count: 2)
+    @old_unit.enrol_student(@student, @campus)
+    @old_unit.active = false
+    @old_unit.start_date -= 1.year
+    @old_unit.end_date -= 1.year
+    @old_unit.save!
+    @old_project = Project.find_by(user: @student, unit: @old_unit)
+    @old_project.update(target_grade: 3)
+
+    # Create webcal
+    @webcal = @student.create_webcal(guid: SecureRandom.uuid)
+  end
+
+  teardown do
+    @webcal.destroy
+    @student.destroy
+    @campus.destroy
+    @old_unit.destroy
+    @current_unit_1.destroy
+    @current_unit_2.destroy
+  end
+
+  test 'Includes only task definitions of current units' do
+    expected_ids = @current_unit_1.task_definitions.map(&:id) + @current_unit_2.task_definitions.map(&:id)
+    actual_ids = @webcal.task_definitions.map(&:id)
+    assert_equal expected_ids.sort, actual_ids.sort
+  end
+
+  test 'Includes only task definitions that are targeted' do
+    # Update target grade to a distinction.
+    g = 2
+    @current_project_1.update(target_grade: g)
+    @current_project_2.update(target_grade: g)
+
+    # Ensure only tasks that are <= distinction are included.
+    expected_ids = @current_unit_1.task_definitions.where("target_grade <= #{g}").map(&:id) + @current_unit_2.task_definitions.where("target_grade <= #{g}").map(&:id)
+    actual_ids = @webcal.task_definitions.map(&:id)
+
+    assert_equal expected_ids.sort, actual_ids.sort
+  end
+
+  test 'Includes only task definitions of units that aren\'t excluded' do
+    # Exclude unit 2
+    @webcal.webcal_unit_exclusions.create(unit: @current_unit_2)
+
+    # Ensure tasks of unit 2 are excluded
+    expected_ids = @current_unit_1.task_definitions.map(&:id)
+    actual_ids = @webcal.task_definitions.map(&:id)
+
+    assert_equal expected_ids.sort, actual_ids.sort
+
+    @webcal.webcal_unit_exclusions.find_by(unit: @current_unit_2).destroy
+  end
+
+  test 'Includes events with target dates of all task definitions' do
+    cal = @webcal.to_ical
+    expected_task_defs = @current_unit_1.task_definitions + @current_unit_2.task_definitions
+
+    assert_equal cal.events.length, expected_task_defs.length
+
+    expected_task_defs.each do |td|
+      td_event = cal.events.detect { |e| e.summary == @webcal.event_name_for_task_definition(td, 'end') }
+      assert_not_nil td_event
+      assert_equal td_event.dtstart.to_date, td.target_date.to_date
+      assert_equal td_event.dtend.to_date, td.target_date.to_date
+    end
+  end
+
+  test 'Includes events for start & end dates if include_start_dates' do
+    @webcal.update(include_start_dates: true)
+
+    cal = @webcal.to_ical
+    expected_task_defs = @current_unit_1.task_definitions + @current_unit_2.task_definitions
+
+    assert_equal cal.events.length, expected_task_defs.length * 2
+
+    expected_task_defs.each do |td|
+      td_start_event = cal.events.detect { |e| e.summary == @webcal.event_name_for_task_definition(td, 'start') }
+      assert_not_nil td_start_event
+      assert_equal td_start_event.dtstart.to_date, td.start_date.to_date
+      assert_equal td_start_event.dtend.to_date, td.start_date.to_date
+
+      td_end_event = cal.events.detect { |e| e.summary == @webcal.event_name_for_task_definition(td, 'end') }
+      assert_not_nil td_end_event
+      assert_equal td_end_event.dtstart.to_date, td.target_date.to_date
+      assert_equal td_end_event.dtend.to_date, td.target_date.to_date
+    end
+
+    @webcal.update(include_start_dates: false)
+  end
+
+  test 'Includes events with extended date if available' do
+
+    # Apply for an extension on one task
+    td = @current_unit_1.task_definitions.first
+    task = @current_project_1.task_for_task_definition(td)
+    comment = task.apply_for_extension(@student, 'extension', 1)
+
+    # Detect corresponding Ical event
+    cal = @webcal.to_ical
+    td_event = cal.events.detect { |e| e.summary == @webcal.event_name_for_task_definition(td, 'end') }
+
+    # Ensure date is the extended date, instead of the target date
+    assert_equal td_event.dtstart.to_date, td.target_date.to_date + 1.week
+    assert_equal td_event.dtend.to_date, td.target_date.to_date + 1.week
+
+    # Revert extension
+    comment.destroy
+    task.update(extensions: 0)
+  end
+end


### PR DESCRIPTION
# Description

Adds functionality that serves key task dates of units that a user is enrolled in, as an iCalendar, importable into Outlook/Google calendars.

The corresponding frontend PR is: https://github.com/doubtfire-lms/doubtfire-web/pull/293

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests ensure that webcals,

- Include only task definitions of current units
- Include only task definitions that are targeted
- Include only task definitions of units that aren't excluded
- Include events with target dates of all task definitions
- Include events for start & end dates if include_start_dates
- Include events with extended date if available

...and that, of the API,

- Setting enabled creates or destroys webcal
- Enables with sensible defaults
- should_change_guid parameter changes the Webcal guid
- Ical endpoint is public and serves webcal with corect content type
- Reminder must be specified with both time & unit

![image](https://user-images.githubusercontent.com/7352580/94506341-7811be00-0250-11eb-9833-2390b1da3953.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
