### PR TITLE
NEW: Pinnable tasks

### DIFF
--- a/app/api/tasks_api.rb
+++ b/app/api/tasks_api.rb
@@ -195,6 +195,28 @@ module Api
       match_link.dismissed
     end
 
+    desc 'Pin a task to the user\'s task inbox'
+    params do
+      requires :id, type: Integer, desc: 'The ID of the task to be pinned'
+    end
+    post '/tasks/:id/pin' do
+      task = Task.find(params[:id])
+
+      unless authorise? current_user, task.unit, :provide_feedback
+        error!({ error: 'Not authorised to pin task' }, 403)
+      end
+
+      TaskPin.find_or_create_by(task: task, user: current_user)
+    end
+
+    desc 'Unpin a task from the user\'s task inbox'
+    params do
+      requires :id, type: Integer, desc: 'The ID of the task to be unpinned'
+    end
+    delete '/tasks/:id/pin' do
+      TaskPin.find_by!(user: current_user, task_id: params[:id]).destroy
+    end
+
     desc 'Update a task using its related project and task definition'
     params do
       # requires :id, type: Integer, desc: 'The project id to locate'

--- a/app/api/units_api.rb
+++ b/app/api/units_api.rb
@@ -204,11 +204,10 @@ module Api
 
     desc 'Pin a task within the task inbox'
     put '/units/:unit_id/tasks/:task_id/pin' do
-      unit = Unit.find(params[:unit_id])
       task = Task.find(params[:task_id])
 
-      unless authorise? current_user, unit, :provide_feedback
-        error!({ error: 'Not authorised to pin task' }, 403) 
+      unless authorise? current_user, task.unit, :provide_feedback
+        error!({ error: 'Not authorised to pin task' }, 403)
       end
 
       TaskPin.find_or_create_by(task: task, user: current_user)
@@ -216,11 +215,10 @@ module Api
 
     desc 'Unpin a task within the task inbox'
     delete '/units/:unit_id/tasks/:task_id/pin' do
-      unit = Unit.find(params[:unit_id])
       task = Task.find(params[:task_id])
-      
-      unless authorise? current_user, unit, :provide_feedback
-        error!({ error: 'Not authorised to unpin task' }, 403) 
+
+      unless authorise? current_user, task.unit, :provide_feedback
+        error!({ error: 'Not authorised to unpin task' }, 403)
       end
 
       TaskPin.find_by(task: task, user: current_user).try(:destroy)

--- a/app/api/units_api.rb
+++ b/app/api/units_api.rb
@@ -215,13 +215,7 @@ module Api
 
     desc 'Unpin a task within the task inbox'
     delete '/units/:unit_id/tasks/:task_id/pin' do
-      task = Task.find(params[:task_id])
-
-      unless authorise? current_user, task.unit, :provide_feedback
-        error!({ error: 'Not authorised to unpin task' }, 403)
-      end
-
-      TaskPin.find_by(task: task, user: current_user).try(:destroy)
+      TaskPin.find_by!(user: current_user, task_id: params[:task_id]).destroy
     end
 
     desc 'Download the tasks that should be listed under the task inbox'

--- a/app/api/units_api.rb
+++ b/app/api/units_api.rb
@@ -202,6 +202,30 @@ module Api
       unit.tasks_as_hash(tasks)
     end
 
+    desc 'Pin a task within the task inbox'
+    put '/units/:unit_id/tasks/:task_id/pin' do
+      unit = Unit.find(params[:unit_id])
+      task = Task.find(params[:task_id])
+
+      unless authorise? current_user, unit, :provide_feedback
+        error!({ error: 'Not authorised to pin task' }, 403) 
+      end
+
+      TaskPin.find_or_create_by(task: task, user: current_user)
+    end
+
+    desc 'Unpin a task within the task inbox'
+    delete '/units/:unit_id/tasks/:task_id/pin' do
+      unit = Unit.find(params[:unit_id])
+      task = Task.find(params[:task_id])
+      
+      unless authorise? current_user, unit, :provide_feedback
+        error!({ error: 'Not authorised to unpin task' }, 403) 
+      end
+
+      TaskPin.find_by(task: task, user: current_user).try(:destroy)
+    end
+
     desc 'Download the tasks that should be listed under the task inbox'
     get '/units/:id/tasks/inbox' do
       unit = Unit.find(params[:id])

--- a/app/api/units_api.rb
+++ b/app/api/units_api.rb
@@ -202,22 +202,6 @@ module Api
       unit.tasks_as_hash(tasks)
     end
 
-    desc 'Pin a task within the task inbox'
-    put '/units/:unit_id/tasks/:task_id/pin' do
-      task = Task.find(params[:task_id])
-
-      unless authorise? current_user, task.unit, :provide_feedback
-        error!({ error: 'Not authorised to pin task' }, 403)
-      end
-
-      TaskPin.find_or_create_by(task: task, user: current_user)
-    end
-
-    desc 'Unpin a task within the task inbox'
-    delete '/units/:unit_id/tasks/:task_id/pin' do
-      TaskPin.find_by!(user: current_user, task_id: params[:task_id]).destroy
-    end
-
     desc 'Download the tasks that should be listed under the task inbox'
     get '/units/:id/tasks/inbox' do
       unit = Unit.find(params[:id])

--- a/app/models/task_pin.rb
+++ b/app/models/task_pin.rb
@@ -1,0 +1,4 @@
+class TaskPin < ActiveRecord::Base
+  belongs_to :task
+  belongs_to :user
+end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1855,7 +1855,7 @@ class Unit < ActiveRecord::Base
         'sq.tutorial_stream_id AS tutorial_stream_id',
         'tasks.id', 
         'SUM(case when crr.user_id is null AND NOT task_comments.id is null then 1 else 0 end) as number_unread',
-        'COUNT(distinct task_pins.task_id) as pinned', 
+        'COUNT(distinct task_pins.task_id) != 0 as pinned',
         'project_id', 
         'tasks.id as task_id',
         'task_definition_id', 

--- a/db/migrate/20200512143828_create_task_pins.rb
+++ b/db/migrate/20200512143828_create_task_pins.rb
@@ -1,10 +1,13 @@
 class CreateTaskPins < ActiveRecord::Migration
   def change
-    create_table :task_pins do |t|
-      t.integer :task_id
-      t.integer :user_id
 
+    create_table :task_pins do |t|
+      t.references :task, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
       t.timestamps null: false
     end
+
+    add_index :task_pins, [:task_id, :user_id], { unique: true }
+
   end
 end

--- a/db/migrate/20200512143828_create_task_pins.rb
+++ b/db/migrate/20200512143828_create_task_pins.rb
@@ -1,0 +1,10 @@
+class CreateTaskPins < ActiveRecord::Migration
+  def change
+    create_table :task_pins do |t|
+      t.integer :task_id
+      t.integer :user_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200327052250) do
+ActiveRecord::Schema.define(version: 20200512143828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -245,6 +245,13 @@ ActiveRecord::Schema.define(version: 20200327052250) do
 
   add_index "task_engagements", ["task_id"], name: "index_task_engagements_on_task_id", using: :btree
 
+  create_table "task_pins", force: :cascade do |t|
+    t.integer  "task_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "task_statuses", force: :cascade do |t|
     t.string   "name",        limit: 255
     t.string   "description", limit: 255
@@ -396,9 +403,7 @@ ActiveRecord::Schema.define(version: 20200327052250) do
     t.string   "last_name",                       limit: 255
     t.string   "username",                        limit: 255
     t.string   "nickname",                        limit: 255
-    t.string   "authentication_token",            limit: 255
     t.string   "unlock_token",                    limit: 255
-    t.datetime "auth_token_expiry"
     t.integer  "role_id",                                     default: 0
     t.boolean  "receive_task_notifications",                  default: true
     t.boolean  "receive_feedback_notifications",              default: true
@@ -407,9 +412,10 @@ ActiveRecord::Schema.define(version: 20200327052250) do
     t.boolean  "has_run_first_time_setup",                    default: false
     t.string   "login_id"
     t.string   "student_id"
+    t.string   "authentication_token",            limit: 255
+    t.datetime "auth_token_expiry"
   end
 
-  add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree
   add_index "users", ["login_id"], name: "index_users_on_login_id", unique: true, using: :btree
 
   add_foreign_key "breaks", "teaching_periods"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -246,11 +246,13 @@ ActiveRecord::Schema.define(version: 20200512143828) do
   add_index "task_engagements", ["task_id"], name: "index_task_engagements_on_task_id", using: :btree
 
   create_table "task_pins", force: :cascade do |t|
-    t.integer  "task_id"
-    t.integer  "user_id"
+    t.integer  "task_id",    null: false
+    t.integer  "user_id",    null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_index "task_pins", ["task_id", "user_id"], name: "index_task_pins_on_task_id_and_user_id", unique: true, using: :btree
 
   create_table "task_statuses", force: :cascade do |t|
     t.string   "name",        limit: 255
@@ -424,6 +426,8 @@ ActiveRecord::Schema.define(version: 20200512143828) do
   add_foreign_key "projects", "campuses"
   add_foreign_key "task_comments", "users", column: "recipient_id"
   add_foreign_key "task_definitions", "tutorial_streams"
+  add_foreign_key "task_pins", "tasks"
+  add_foreign_key "task_pins", "users"
   add_foreign_key "tutorial_enrolments", "projects"
   add_foreign_key "tutorial_enrolments", "tutorials"
   add_foreign_key "tutorial_streams", "activity_types"

--- a/test/api/tasks_test.rb
+++ b/test/api/tasks_test.rb
@@ -243,27 +243,27 @@ class TasksTest < ActiveSupport::TestCase
 
     # Convenor tries to pin task
     post with_auth_token("/api/tasks/#{task.id}/pin", convenor)
-    assert last_response.status, 201
+    assert_equal last_response.status, 201
 
     # Convenor tries to unpin task
     delete with_auth_token("/api/tasks/#{task.id}/pin", convenor)
-    assert last_response.status, 200
+    assert_equal last_response.status, 200
 
     # Tutor tries to pin task
     post with_auth_token("/api/tasks/#{task.id}/pin", tutor)
-    assert last_response.status, 201
+    assert_equal last_response.status, 201
 
     # Tutor tries to unpin task
     delete with_auth_token("/api/tasks/#{task.id}/pin", tutor)
-    assert last_response.status, 200
+    assert_equal last_response.status, 200
 
     # Student tries to pin task
     post with_auth_token("/api/tasks/#{task.id}/pin", student)
-    assert last_response.status, 403
+    assert_equal last_response.status, 403
 
     # Admin tries to pin task
     post with_auth_token("/api/tasks/#{task.id}/pin", admin)
-    assert last_response.status, 403
+    assert_equal last_response.status, 403
   end
 
   def test_convenors_tutors_can_pin_tasks_of_their_units_only
@@ -281,19 +281,19 @@ class TasksTest < ActiveSupport::TestCase
 
     # Convenor tries to pin task of unit that they are assigned to
     post with_auth_token("/api/tasks/#{task.id}/pin", convenor)
-    assert last_response.status, 201
+    assert_equal last_response.status, 201
 
     # Tutor tries to pin task of unit that they are assigned to
     post with_auth_token("/api/tasks/#{task.id}/pin", tutor)
-    assert last_response.status, 201
+    assert_equal last_response.status, 201
 
     # Convenor tries to pin task of unit that they are not assigned to
     post with_auth_token("/api/tasks/#{other_task.id}/pin", convenor)
-    assert last_response.status, 403
+    assert_equal last_response.status, 403
 
     # Tutor tries to pin task of unit that they are not assigned to
     post with_auth_token("/api/tasks/#{other_task.id}/pin", tutor)
-    assert last_response.status, 403
+    assert_equal last_response.status, 403
   end
 
   def test_tasks_for_inbox_include_pinned_status

--- a/test/api/tasks_test.rb
+++ b/test/api/tasks_test.rb
@@ -228,4 +228,90 @@ class TasksTest < ActiveSupport::TestCase
     td.destroy
   end
 
+  def test_convenors_tutors_can_pin_and_unpin_tasks_students_admins_cannot
+    unit = FactoryBot.create(:unit, student_count: 1, task_count: 1, perform_submissions: true)
+    task = unit.tasks.first
+
+    convenor = FactoryBot.create(:user, :convenor)
+    tutor = FactoryBot.create(:user, :tutor)
+    student = FactoryBot.create(:user, :student)
+    admin = FactoryBot.create(:user, :admin)
+
+    unit.employ_staff(convenor, Role.convenor)
+    unit.employ_staff(tutor, Role.tutor)
+    unit.enrol_student(student, FactoryBot.create(:campus))
+
+    # Convenor tries to pin task
+    post with_auth_token("/api/tasks/#{task.id}/pin", convenor)
+    assert last_response.status, 201
+
+    # Convenor tries to unpin task
+    delete with_auth_token("/api/tasks/#{task.id}/pin", convenor)
+    assert last_response.status, 200
+
+    # Tutor tries to pin task
+    post with_auth_token("/api/tasks/#{task.id}/pin", tutor)
+    assert last_response.status, 201
+
+    # Tutor tries to unpin task
+    delete with_auth_token("/api/tasks/#{task.id}/pin", tutor)
+    assert last_response.status, 200
+
+    # Student tries to pin task
+    post with_auth_token("/api/tasks/#{task.id}/pin", student)
+    assert last_response.status, 403
+
+    # Admin tries to pin task
+    post with_auth_token("/api/tasks/#{task.id}/pin", admin)
+    assert last_response.status, 403
+  end
+
+  def test_convenors_tutors_can_pin_tasks_of_their_units_only
+    unit = FactoryBot.create(:unit, student_count: 1, task_count: 1, perform_submissions: true)
+    task = unit.tasks.first
+
+    convenor = FactoryBot.create(:user, :convenor)
+    tutor = FactoryBot.create(:user, :tutor)
+
+    unit.employ_staff(convenor, Role.convenor)
+    unit.employ_staff(tutor, Role.tutor)
+
+    other_unit = FactoryBot.create(:unit, student_count: 1, task_count: 1, perform_submissions: true)
+    other_task = other_unit.tasks.first
+
+    # Convenor tries to pin task of unit that they are assigned to
+    post with_auth_token("/api/tasks/#{task.id}/pin", convenor)
+    assert last_response.status, 201
+
+    # Tutor tries to pin task of unit that they are assigned to
+    post with_auth_token("/api/tasks/#{task.id}/pin", tutor)
+    assert last_response.status, 201
+
+    # Convenor tries to pin task of unit that they are not assigned to
+    post with_auth_token("/api/tasks/#{other_task.id}/pin", convenor)
+    assert last_response.status, 403
+
+    # Tutor tries to pin task of unit that they are not assigned to
+    post with_auth_token("/api/tasks/#{other_task.id}/pin", tutor)
+    assert last_response.status, 403
+  end
+
+  def test_tasks_for_inbox_include_pinned_status
+    unit = FactoryBot.create(:unit, student_count: 1, task_count: 2, perform_submissions: true)
+    task1, task2 = unit.tasks.limit(2)
+
+    tutor = FactoryBot.create(:user, :tutor)
+    unit.employ_staff(tutor, Role.tutor)
+
+    # Tutor pins task 1
+    post with_auth_token("/api/tasks/#{task1.id}/pin", tutor)
+
+    # Tutor retrieves task inbox
+    get with_auth_token("/api/units/#{unit.id}/tasks/inbox", tutor)
+
+    # Assert that task1 is pinned, task2 isn't
+    assert last_response_body.detect { |t| t['id'] == task1.id }['pinned']
+    assert_not last_response_body.detect { |t| t['id'] == task2.id }['pinned']
+  end
+
 end

--- a/test/factories/task_pins.rb
+++ b/test/factories/task_pins.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :task_pin do
+    task { 1 }
+    user { 1 }
+  end
+end

--- a/test/models/task_pin_test.rb
+++ b/test/models/task_pin_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class TaskPinTest < ActiveSupport::TestCase
+  def task_pin
+    @task_pin ||= TaskPin.new
+  end
+
+  def test_valid
+    assert task_pin.valid?
+  end
+end


### PR DESCRIPTION
# Description

This branch continues @Justfeedme's work in making tasks pinnable #280.

Introduces 2 new endpoints,

![](https://user-images.githubusercontent.com/7352580/94033283-273f3700-fe04-11ea-9533-071cc8b57379.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

https://github.com/doubtfire-lms/doubtfire-api/pull/292/commits/dca86d57791f94c58f08ba7be6390c183cb986fd includes the following tests,

1. Tasks are un/pinnable by tutors & convenors, and not by students & admins.
2. Tutors & convenors only pin tasks of units to which they are assigned.
3. The list of tasks returned for the task inbox includes their un/pinned states.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~I have made corresponding changes to the documentation if appropriate~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [x] ~Any dependent changes have been merged and published in downstream modules~