### PR TITLE
FIX: Ensure new files override unprocessed files

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1171,12 +1171,19 @@ class Task < ActiveRecord::Base
     #
     # Now copy over the temp directory over to the enqueued directory
     #
-    enqueued_dir = FileHelper.student_work_dir(:new, nil, true)[0..-2]
+    enqueued_dir = File.join(FileHelper.student_work_dir(:new, nil, true), id.to_s)
 
-    logger.debug "Moving submission evidence from #{tmp_dir} to #{enqueued_dir}"
+    # Move files into place, deleting existing files if present.
+    if not File.exists? enqueued_dir
+      logger.debug "Creating student work new dir #{enqueued_dir}"
+      FileUtils.mkdir_p enqueued_dir
+    end
 
-    # Move files into place
-    FileUtils.mv tmp_dir, enqueued_dir, :force => true
+    logger.debug "Moving source files from #{tmp_dir} into #{enqueued_dir}"
+    FileUtils.mv Dir.glob(File.join(tmp_dir,'*.*')), enqueued_dir, force: true
+
+    logger.debug "Deleting student work dir: #{tmp_dir}"
+    FileUtils.rm_rf tmp_dir if File.exists? tmp_dir
 
     logger.debug "Submission accepted! Status for task #{id} is now #{trigger}"
   end


### PR DESCRIPTION
# Description

This PR fixes a bug in which new files uploaded via the "Update files" (rather than a new submission) wouldn't override unprocessed new files.

For example:

Submission fileset#1 -> Update Files with fileset#2 -> PDF Generated would generate with fileset#1.

The issue was caused by FileUtils.mv not operating as expected.

In fact, the underlying unix mv command generated by the FileUtils method *does* work as expected, which seems to indicate to me a bug in FileUtils. This solution is a workaround while still retaining the benefits of using mv (files are still renamed not copied).

Fixes # (issue)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing unit tests run successfully, although new unit tests to test for this bug should be written I am authoring the PR now as this *may* be a critical bug worth deploying ASAP.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if appropriate
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created or extended unit tests to address my new additions
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
