### PR TITLE
FIX: Fix updating unit on units API when draft learning summary id is null or empty

### DIFF
--- a/app/api/units_api.rb
+++ b/app/api/units_api.rb
@@ -102,7 +102,7 @@ module Api
         unit.teaching_period = nil
       end
 
-      if unit_parameters[:draft_task_definition_id]
+      if unit_parameters[:draft_task_definition_id].present?
         # Ensure the task definition belongs to unit
         unless unit.task_definitions.exists?(unit_parameters[:draft_task_definition_id])
           error!({ error: 'Draft task definition ID does not belong to unit' }, 403)

--- a/app/api/units_api.rb
+++ b/app/api/units_api.rb
@@ -102,7 +102,7 @@ module Api
         unit.teaching_period = nil
       end
 
-      if unit_parameters.key?(:draft_task_definition_id)
+      if unit_parameters[:draft_task_definition_id]
         # Ensure the task definition belongs to unit
         unless unit.task_definitions.exists?(unit_parameters[:draft_task_definition_id])
           error!({ error: 'Draft task definition ID does not belong to unit' }, 403)


### PR DESCRIPTION
# Description

A bug existed where when using `.key?` when detecting if a draft task definition id was passed into the parameters would also equate to `true` when the front-end returned null or an empty string.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The tests previously created in `units_api_tests.rb` have no failures.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules