### PR TITLE
Fix/portfolio mailer

### DIFF
--- a/app/mailers/portfolio_evidence_mailer.rb
+++ b/app/mailers/portfolio_evidence_mailer.rb
@@ -62,7 +62,7 @@ class PortfolioEvidenceMailer < ActionMailer::Base
 
     @student = project.student
     @project = project
-    @convenor = project.unit.convenors.first.user
+    @convenor = project.main_convenor_user
 
     email_with_name = %("#{@student.name}" <#{@student.email}>)
     convenor_email = %("#{@convenor.name}" <#{@convenor.email}>)
@@ -77,7 +77,7 @@ class PortfolioEvidenceMailer < ActionMailer::Base
     
     @student = project.student
     @project = project
-    @convenor = project.unit.convenors.first.user
+    @convenor = project.main_convenor_user
 
     email_with_name = %("#{@student.name}" <#{@student.email}>)
     convenor_email = %("#{@convenor.name}" <#{@convenor.email}>)

--- a/test/mailers/unit_mail_test.rb
+++ b/test/mailers/unit_mail_test.rb
@@ -18,4 +18,20 @@ class UnitMailTest < ActionMailer::TestCase
     assert_equal unit.active_projects.count + 1, ActionMailer::Base.deliveries.count
   end
 
+  def test_send_portfolio_ready_from_main_convenor
+    unit = FactoryBot.create :unit
+    convenor = FactoryBot.create :user, :convenor
+
+    ur = unit.employ_staff convenor, Role.convenor
+
+    unit.update main_convenor: ur
+
+    project = unit.active_projects.first
+
+    mail = PortfolioEvidenceMailer.portfolio_ready(project)
+
+    assert_equal 1, mail.from().count
+    assert_equal convenor.email, mail.from().first
+  end
+
 end

--- a/test/mailers/unit_mail_test.rb
+++ b/test/mailers/unit_mail_test.rb
@@ -34,4 +34,20 @@ class UnitMailTest < ActionMailer::TestCase
     assert_equal convenor.email, mail.from().first
   end
 
+  def test_send_portfolio_fail_from_main_convenor
+    unit = FactoryBot.create :unit
+    convenor = FactoryBot.create :user, :convenor
+
+    ur = unit.employ_staff convenor, Role.convenor
+
+    unit.update main_convenor: ur
+
+    project = unit.active_projects.first
+
+    mail = PortfolioEvidenceMailer.portfolio_failed(project)
+
+    assert_equal 1, mail.from().count
+    assert_equal convenor.email, mail.from().first
+  end
+
 end


### PR DESCRIPTION
# Description

Existing portfolio mailer send using the first convenor user. This is not always the main convenor, and should have been updated to correct this issue with the main convenor patch. This PR adds tests to verify this issue and then resolves the problem.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New tests added to check sending of fail and success portfolio messages.