### PR TITLE
Upgrade rmagick to work with latest image magic deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'json-jwt', '1.7.0'
 # Student submission
 gem 'coderay'
 gem 'ruby-filemagic'
-gem 'rmagick', '~> 2.15' # require: false #already included in other gems - remove to avoid duplicate errors
+gem 'rmagick', '~> 4.1' # require: false #already included in other gems - remove to avoid duplicate errors
 gem 'rubyzip'
 
 # Plagarism detection

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rmagick (2.16.0)
+    rmagick (4.1.2)
     roo (2.7.1)
       nokogiri (~> 1)
       rubyzip (~> 1.1, < 2.0.0)
@@ -314,7 +314,7 @@ DEPENDENCIES
   rails_best_practices
   require_all (>= 1.3.3)
   rest-client (~> 2.0)
-  rmagick (~> 2.15)
+  rmagick (~> 4.1)
   roo (~> 2.7.0)
   roo-xls
   rubocop (= 0.46.0)


### PR DESCRIPTION
# Description

Latest updates on the deployment server use a version of image magic that is not compatible with the existing version. This PR updates the rmagick version and has tested that this update does not cause issues.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

When deployed the bundle will need to be reinstalled
