### PR TITLE
FIX: Correct student list query to ensure all students appear

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -560,6 +560,11 @@ class Project < ActiveRecord::Base
   # Total task counts must contain an array of the cummulative task counts (with none being 0)
   # Project task counts is an object with fail_count, complete_count etc for each status
   def self.create_task_stats_from(total_task_counts, project_task_counts, target_grade)
+
+    TaskStatus.all.each  do |s|
+      project_task_counts["#{s.status_key}_count"] = 0 if project_task_counts["#{s.status_key}_count"].nil?
+    end
+
     red_pct = ((project_task_counts.fail_count + project_task_counts.do_not_resubmit_count + project_task_counts.time_exceeded_count) / total_task_counts[target_grade]).signif(2)
     orange_pct = ((project_task_counts.redo_count + project_task_counts.need_help_count + project_task_counts.fix_and_resubmit_count) / total_task_counts[target_grade]).signif(2)
     green_pct = ((project_task_counts.discuss_count + project_task_counts.demonstrate_count + project_task_counts.complete_count) / total_task_counts[target_grade]).signif(2)

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -318,10 +318,9 @@ class Unit < ActiveRecord::Base
     # Get the task stats for a student as a subquery so that it is independent of the main query
     # otherwise an attempt at a higher level task can exclude the student from the student list! 
     subquery = projects.
-      joins('LEFT OUTER JOIN tasks ON projects.id = tasks.project_id').
-      joins('LEFT JOIN task_definitions ON tasks.task_definition_id = task_definitions.id').
+      joins(tasks: :task_definition).
       where(
-        'projects.target_grade >= task_definitions.target_grade OR (task_definitions.target_grade IS NULL)'
+        'projects.target_grade >= task_definitions.target_grade'
       ).
       group('projects.id').
       select(


### PR DESCRIPTION
This fixes an issue where students could disappear from Doubtfire if they only had tasks for task definitions higher than their target grade.