### PR TITLE
Correctly assign webcal reminder descriptions. Fixes #316

### DIFF
--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -98,7 +98,7 @@ class Webcal < ActiveRecord::Base
           if ev_reminders
             ev.alarm do |a|
               a.action = 'DISPLAY'
-              a.description = ev_summary
+              a.description = ev.summary
               a.trigger = ev_reminder_trigger
             end
           end
@@ -117,7 +117,7 @@ class Webcal < ActiveRecord::Base
         if ev_reminders
           ev.alarm do |a|
             a.action = 'DISPLAY'
-            a.description = ev_summary
+            a.description = ev.summary
             a.trigger = ev_reminder_trigger
           end
         end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210310000709) do
+ActiveRecord::Schema.define(version: 20210413044542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/test/api/webcal_api_test.rb
+++ b/test/api/webcal_api_test.rb
@@ -85,18 +85,22 @@ class UnitsTest < ActiveSupport::TestCase
 
     # Specify only time
     put_json '/api/webcal', with_auth_token({ webcal: { reminder: { time: 5 } } }, @student)
-    assert 400, last_response.status
+    assert_equal 400, last_response.status
 
     # Specify only unit
     put_json '/api/webcal', with_auth_token({ webcal: { reminder: { unit: 'D' } } }, @student)
-    assert 400, last_response.status
+    assert_equal 400, last_response.status
 
     # Specify both time & unit
-    put_json '/api/webcal', with_auth_token({ webcal: { reminder: { time: 5, unit: 'D' } } }, @student)
-    assert 200, last_response.status
+    Webcal.valid_time_units.each_with_index { |u, i|
+      t = i + 1
 
-    webcal.reload
-    assert_equal 5, webcal.reminder_time
-    assert_equal 'D', webcal.reminder_unit
+      put_json '/api/webcal', with_auth_token({ webcal: { reminder: { time: t, unit: u } } }, @student)
+      assert_equal 200, last_response.status
+
+      webcal.reload
+      assert_equal t, webcal.reminder_time
+      assert_equal u, webcal.reminder_unit
+    }
   end
 end


### PR DESCRIPTION
# Description

Issue described at, and fixes #316 

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `webcal_test.rb` → `Includes webcal reminders correctly` added in 2a9a5e6a1a9e96be926d18a2da908bb7313473f7 exposes the issue. @macite I'd like to know your thoughts on this test case if you don't mind, thanks 😅.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
