### PR TITLE
FIX: Remove hardcoded user ID in webcal unit exclusion logic

### DIFF
--- a/app/api/webcal_api.rb
+++ b/app/api/webcal_api.rb
@@ -107,7 +107,7 @@ module Api
             Unit
               .joins(:projects)
               .where(
-                projects: { user_id: 7 },
+                projects: { user_id: user.id },
                 units: { id: webcal_params[:unit_exclusions], active: true }
               )
               .pluck(:id)


### PR DESCRIPTION
# Description

This removes the user id `7` that was mistakenly hardcoded in the webcal API unit exclusion logic in cc13c5630e5f486c75b61b385ed1f2cc7392f40f.

Not sure how I missed this ...just 😐😶🤦.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `Can update unit exclusions`
       https://github.com/doubtfire-lms/doubtfire-api/blob/d7e66aa353dd88da98d51c30732ad4ad674090da/test/api/webcal_api_test.rb#L112-L133
       👆 which hits 👇<br>
       https://github.com/doubtfire-lms/doubtfire-api/blob/1037242d44a1dfaeda0db80b42a4ae1da4b69579/app/api/webcal_api.rb#L104-L116

- [x] Several other refinements to webcal api tests in 79c55aa139b3a7deb33ac63111ddf3c894716ba2 that make them consistent with notion of "API tests"—creating webcals via the `PUT /webcal` endpoint instead of creating DB entities directly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~I have made corresponding changes to the documentation if appropriate~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created or extended unit tests to address my new additions
- [ ] New and existing unit tests pass locally with my changes
      Installing `texlive-full` now; will update with a screenshot.
- [x] ~Any dependent changes have been merged and published in downstream modules~
