### PR TITLE
PDF generation draft initialization

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -4,6 +4,7 @@ require 'csv'
 require 'yaml'
 require 'grape-active_model_serializers'
 require 'bunny-pub-sub/services_manager'
+require_relative '../lib/assets/ontrack_receive_action.rb'
 
 # Precompile assets before deploying to production
 if defined?(Bundler)
@@ -158,9 +159,21 @@ module Doubtfire
         # This is enough for now:
         DEFAULT_BINDING_KEY: '*.result'
       }
+      
+      pdf_subscriber_config = {
+        RABBITMQ_HOSTNAME: ENV['RABBITMQ_HOSTNAME'],
+        RABBITMQ_USERNAME: ENV['RABBITMQ_USERNAME'],
+        RABBITMQ_PASSWORD: ENV['RABBITMQ_PASSWORD'],
+        EXCHANGE_NAME: 'ontrack',
+        DURABLE_QUEUE_NAME: 'q.tasks',
+        BINDING_KEYS: 'task.submission',
+        DEFAULT_BINDING_KEY: 'task.submission'
+      }
 
       config.sm_instance = ServicesManager.instance
       config.sm_instance.register_client(:ontrack, publisher_config, subscriber_config)
+
+      register_subscriber(pdf_subscriber_config, method(:receive), nil)
     end
 
   end

--- a/lib/tasks/pdfgen.rake
+++ b/lib/tasks/pdfgen.rake
@@ -1,0 +1,28 @@
+require_relative '../assets/ontrack_receive_action.rb'
+
+namespace :submission do
+  desc 'Start listening for tasks in tasks.submission, then convert to pdf'
+  task pdfgen: [:environment] do
+    sm_instance = Doubtfire::Application.config.sm_instance
+
+    if sm_instance.nil?
+      puts "ServiceManager is not initialised."
+      return
+    end
+
+    sm_instance.clients[:ontrack].action = method(:receive)
+    sm_instance.clients[:ontrack].start_subscriber
+
+    task = Task.find(params[:task_id])
+
+    begin
+      logger.info "creating pdf for task #{task.id}"
+      task_pdf = task.convert_submission_to_pdf
+
+    rescue Exception => e
+      add_error.call(e.message.to_s)
+    end
+
+    puts "Bye!"
+  end
+end


### PR DESCRIPTION
# **PDF Generation Draft PR** 

Initial setup of PDF generation process as we created pdf gen subscriber and a rake task that start the whole process.

Co-authored by @kiratkaur13 

# Current issues and TODO list:

- [ ] Issues with subscriber registration 
- [ ] Code is not yet complete as we are missing some error exceptions
- [ ] Setting up binding keys
- [ ] Test the system by submitting a task through front-end and see if the back-end gets it. 
- [ ] Bug fixes