### PR TITLE
Perf/fix project and unit load times

### DIFF
--- a/.ci-setup/pdfGen/crontab
+++ b/.ci-setup/pdfGen/crontab
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 BASH_ENV=/container.env
 PATH=/tmp/texlive/bin/x86_64-linux:/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bundle/bin
 
-10,15,20,25,30,35,40,45,50,55 * * * * /doubtfire/lib/shell/generate_pdfs.sh > /proc/1/fd/1 2>/proc/1/fd/2
-0 5 * * 1,3,5 /doubtfire/lib/shell/check_plagiarism.sh > /proc/1/fd/1 2>/proc/1/fd/2
-0 7 * * 1 /doubtfire/lib/shell/send_weekly_emails.sh > /proc/1/fd/1 2>/proc/1/fd/2
-0 1 * * * /doubtfire/lib/shell/sync_enrolments.sh > /proc/1/fd/1 2>/proc/1/fd/2
+10,15,20,25,30,35,40,45,50,55 * * * * /doubtfire/lib/shell/generate_pdfs.sh
+0 5 * * 1,3,5 /doubtfire/lib/shell/check_plagiarism.sh
+0 7 * * 1 /doubtfire/lib/shell/send_weekly_emails.sh
+0 1 * * * /doubtfire/lib/shell/sync_enrolments.sh

--- a/app/api/projects_api.rb
+++ b/app/api/projects_api.rb
@@ -192,7 +192,7 @@ class ProjectsApi < Grape::API
           grade_rationale: proj.grade_rationale,
           max_pct_copy: 0,
           has_portfolio: false,
-          stats: '0|1|0|0|0|0|0|0|0|0|0'
+          stats: Project.DEFAULT_TASK_STATS
         }
         present result, with: Grape::Presenters::Presenter
       end

--- a/app/api/projects_api.rb
+++ b/app/api/projects_api.rb
@@ -192,7 +192,7 @@ class ProjectsApi < Grape::API
           grade_rationale: proj.grade_rationale,
           max_pct_copy: 0,
           has_portfolio: false,
-          stats: Project.DEFAULT_TASK_STATS
+          stats: Project::DEFAULT_TASK_STATS
         }
         present result, with: Grape::Presenters::Presenter
       end

--- a/app/helpers/grade_helper.rb
+++ b/app/helpers/grade_helper.rb
@@ -33,6 +33,10 @@ module GradeHelper
     end
   end
 
+  PASS_VALUE = 0
+  HD_VALUE = 3
+  RANGE = PASS_VALUE..HD_VALUE
+
   module_function :grade_for
   module_function :short_grade_for
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -565,6 +565,15 @@ class Project < ApplicationRecord
     end
   end
 
+  DEFAULT_TASK_STATS = {
+    red_pct: 0,
+    grey_pct: 1,
+    orange_pct: 0,
+    blue_pct: 0,
+    green_pct: 0,
+    order_scale: 0
+  }.freeze
+
   # Calculate the task stats text to send progress data back to the client
   # Total task counts must contain an array of the cummulative task counts (with none being 0)
   # Project task counts is an object with fail_count, complete_count etc for each status
@@ -629,15 +638,9 @@ class Project < ApplicationRecord
         .map do |t| Project.create_task_stats_from(task_count, t, target_grade) end
         .first
 
+    # There may be no row however... in which case use the defaults
     if result.nil?
-      result = {
-        red_pct: 0,
-        grey_pct: 1,
-        orange_pct: 0,
-        blue_pct: 0,
-        green_pct: 0,
-        order_scale: 0
-      }
+      result = DEFAULT_TASK_STATS
     else
       result
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -114,6 +114,9 @@ class Task < ApplicationRecord
   delegate :upload_requirements, to: :task_definition
   delegate :name, to: :task_definition
   delegate :target_date, to: :task_definition
+  delegate :update_task_stats, to: :project
+
+  after_update :update_task_stats, if: :saved_change_to_task_status_id?
 
   validates :task_definition_id, uniqueness: { scope: :project,
                                                message: 'must be unique within the project' }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -116,7 +116,7 @@ class Task < ApplicationRecord
   delegate :target_date, to: :task_definition
   delegate :update_task_stats, to: :project
 
-  after_update :update_task_stats, if: :saved_change_to_task_status_id?
+  after_update :update_task_stats, if: :saved_change_to_task_status_id? #TODO: consider moving to async task
 
   validates :task_definition_id, uniqueness: { scope: :project,
                                                message: 'must be unique within the project' }

--- a/app/models/task_definition.rb
+++ b/app/models/task_definition.rb
@@ -28,7 +28,7 @@ class TaskDefinition < ApplicationRecord
   validates :name, uniqueness: { scope:  :unit_id } # task definition names within a unit must be unique
   validates :abbreviation, uniqueness: { scope: :unit_id } # task definition names within a unit must be unique
 
-  validates :target_grade, inclusion: { in: 0..3, message: '%{value} is not a valid target grade' }
+  validates :target_grade, inclusion: { in: GradeHelper::RANGE, message: '%{value} is not a valid target grade' }
   validates :max_quality_pts, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 10, message: 'must be between 0 and 10' }
 
   validates :upload_requirements, length: { maximum: 4095, allow_blank: true }

--- a/app/models/task_status.rb
+++ b/app/models/task_status.rb
@@ -2,6 +2,8 @@
 # The status
 # - has a name and a description
 class TaskStatus < ApplicationRecord
+  #TODO: Consider refactoring this class. Is there any point to having this in the database? Could this become an enum?
+
   # Model associations
   has_many :tasks
 

--- a/app/models/task_status.rb
+++ b/app/models/task_status.rb
@@ -62,6 +62,11 @@ class TaskStatus < ApplicationRecord
     TaskStatus.find(12)
   end
 
+  class << self
+    # Provide access to the count from the database via a new db_count method
+    alias_method :db_count, :count
+  end
+
   # Return the count (which equals the largest id) - so that other code can loop thought all statuses without database lookup
   #
   # Make sure to update this if/when you add another status!

--- a/app/models/task_status.rb
+++ b/app/models/task_status.rb
@@ -62,6 +62,15 @@ class TaskStatus < ApplicationRecord
     TaskStatus.find(12)
   end
 
+  # Return the count (which equals the largest id) - so that other code can loop thought all statuses without database lookup
+  #
+  # Make sure to update this if/when you add another status!
+  #
+  # Keep this hard coded! Saves cache load time.
+  # Important: count must equal the largest id in the database
+  def self.count
+    12
+  end
 
   def self.status_for_name(name)
     case name.downcase.strip

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -465,7 +465,7 @@ class Unit < ApplicationRecord
     Project.create!(
       user_id: user.id,
       unit_id: id,
-      task_stats: '0.0|1.0|0.0|0.0|0.0|0.0',
+      task_stats: Project::DEFAULT_TASK_STATS,
       campus: campus
     )
   end

--- a/db/migrate/20210413044542_change_do_not_resubmit.rb
+++ b/db/migrate/20210413044542_change_do_not_resubmit.rb
@@ -1,6 +1,6 @@
 class ChangeDoNotResubmit < ActiveRecord::Migration[4.2]
   def change
-    if TaskStatus.count_by_sql > 0
+    if TaskStatus.db_count > 0
       dnr = TaskStatus.feedback_exceeded
       TaskStatusComment.where(task_status: dnr).update_all(comment: 'Feedback Exceeded')
       dnr.name = 'Feedback Exceeded'

--- a/db/migrate/20210413044542_change_do_not_resubmit.rb
+++ b/db/migrate/20210413044542_change_do_not_resubmit.rb
@@ -1,6 +1,6 @@
 class ChangeDoNotResubmit < ActiveRecord::Migration[4.2]
   def change
-    if TaskStatus.count > 0
+    if TaskStatus.count_by_sql > 0
       dnr = TaskStatus.feedback_exceeded
       TaskStatusComment.where(task_status: dnr).update_all(comment: 'Feedback Exceeded')
       dnr.name = 'Feedback Exceeded'

--- a/db/migrate/20220310092851_update_task_stats.rb
+++ b/db/migrate/20220310092851_update_task_stats.rb
@@ -1,8 +1,8 @@
 class UpdateTaskStats < ActiveRecord::Migration[7.0]
   def change
     # Migrate all projects data - update the task stats
-    Project.all.each do |project|
-      project.update_task_stats
+    Project.find_in_batches do |projects|
+      projects.each { |project| project.update_task_stats }
     end
   end
 end

--- a/db/migrate/20220310092851_update_task_stats.rb
+++ b/db/migrate/20220310092851_update_task_stats.rb
@@ -1,0 +1,8 @@
+class UpdateTaskStats < ActiveRecord::Migration[7.0]
+  def change
+    # Migrate all projects data - update the task stats
+    Project.all.each do |project|
+      project.update_task_stats
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_10_052033) do
+ActiveRecord::Schema.define(version: 2022_03_10_092851) do
 
   create_table "activity_types", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       DF_STUDENT_WORK_DIR: /student-work
       DF_INSTITUTION_HOST: http://localhost:3000
       DF_INSTITUTION_PRODUCT_NAME: OnTrack
+      DF_INSTITUTION_PRODUCT_VERSION: 0.0.1
+      DF_INSTITUTION_NAME: Doubtfire
 
       DF_SECRET_KEY_BASE: test-secret-key-test-secret-key!
       DF_SECRET_KEY_ATTR: test-secret-key-test-secret-key!

--- a/lib/tasks/init.rake
+++ b/lib/tasks/init.rake
@@ -24,7 +24,7 @@ namespace :db do
   # Generate tasks statuses
   #
   def generate_task_statuses
-    return if TaskStatus.count > 0
+    return if TaskStatus.count_by_sql > 0
     puts "-> Generating task statuses"
     statuses = {
       "Not Started": "You have not yet started this task.",

--- a/lib/tasks/init.rake
+++ b/lib/tasks/init.rake
@@ -24,7 +24,7 @@ namespace :db do
   # Generate tasks statuses
   #
   def generate_task_statuses
-    return if TaskStatus.count_by_sql > 0
+    return if TaskStatus.db_count > 0
     puts "-> Generating task statuses"
     statuses = {
       "Not Started": "You have not yet started this task.",

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -25,7 +25,7 @@ namespace :db do
         p.tasks.destroy_all
         p.remove_portfolio
 
-        p.target_grade = rand(0..3)
+        p.target_grade = rand(GradeHelper::RANGE)
 
         case rand(1..100)
         when 0..5

--- a/test/factories/units_factory.rb
+++ b/test/factories/units_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     unit
     name                      { Faker::Lorem.unique.word }
     description               { Faker::Lorem.sentence }
-    target_grade              { rand(0..3) }
+    target_grade              { rand(GradeHelper::RANGE) }
     upload_requirements       { [{'key' => 'file0','name' => 'Imported Code','type' => 'code'}] }
     start_date                { unit.start_date + rand(1..12).weeks }
     sequence(:abbreviation)   { |n| "#{GradeHelper.short_grade_for target_grade}#{((unit.start_date - start_date) / 1.week).floor + 1}.#{n}" }

--- a/test/factories/units_factory.rb
+++ b/test/factories/units_factory.rb
@@ -171,7 +171,7 @@ FactoryBot.define do
       if eval.perform_submissions
         task_definitions.each_with_index do |td, i|
           unit.active_projects.each_with_index do |p, j|
-            ts = TaskStatus.all[(i + j) % TaskStatus.count_by_sql]
+            ts = TaskStatus.all[(i + j) % TaskStatus.db_count]
             next if ts == TaskStatus.not_started
             task = p.task_for_task_definition td
             tutor = p.tutor_for(td)

--- a/test/factories/units_factory.rb
+++ b/test/factories/units_factory.rb
@@ -171,7 +171,7 @@ FactoryBot.define do
       if eval.perform_submissions
         task_definitions.each_with_index do |td, i|
           unit.active_projects.each_with_index do |p, j|
-            ts = TaskStatus.all[(i + j) % TaskStatus.count]
+            ts = TaskStatus.all[(i + j) % TaskStatus.count_by_sql]
             next if ts == TaskStatus.not_started
             task = p.task_for_task_definition td
             tutor = p.tutor_for(td)


### PR DESCRIPTION
# Description

This PR reinstates the task_stats data for the front end and improves the load time performance of units. This is done by caching the task_stats in the project and updating this on task status change and change of target grade. As a result, this can be loaded from the database on the students query.
