### PR TITLE
Fix: stop empty nicknames from rendering in student_name

### DIFF
--- a/app/api/entities/project_entity.rb
+++ b/app/api/entities/project_entity.rb
@@ -7,7 +7,7 @@ module Entities
     end
     expose :campus_id
     expose :student_name do |project, options|
-      "#{project.student.name}#{project.student.nickname.nil? ? '' : ' (' << project.student.nickname << ')'}"
+      "#{project.student.name}#{project.student.nickname.blank? ? '' : ' (' << project.student.nickname << ')'}"
     end
     expose :enrolled
     expose :target_grade


### PR DESCRIPTION
refactor ternary operator which creates student_name to ensure nicknames with a value of "" are not rendered

# Description

Replaced the .nil? check with .blank? to ensure a nickname with an empty string won't be added to project_entity::student_name.

Fixes #363 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
