### PR TITLE
fix:fix the manual delete servers.pid file after restart container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,7 @@ EXPOSE 3000
 
 ENV RAILS_ENV development
 CMD bundle exec rake db:migrate && bundle exec rails s -b 0.0.0.0
+
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,4 @@ COPY . .
 EXPOSE 3000
 
 ENV RAILS_ENV development
-CMD bundle exec rake db:migrate && bundle exec rails s -b 0.0.0.0
-
-COPY ./docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
-ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD  rm -f tmp/pids/server.pid && bundle exec rake db:migrate && bundle exec rails s -b 0.0.0.0

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+exec bundle exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-rm -f tmp/pids/server.pid
-
-exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,4 +3,4 @@ set -e
 
 rm -f tmp/pids/server.pid
 
-exec bundle exec "$@"
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-if [ -f tmp/pids/server.pid ]; then
-  rm tmp/pids/server.pid
-fi
+rm -f tmp/pids/server.pid
 
 exec bundle exec "$@"


### PR DESCRIPTION

# Description

When we restart the doubtfire-api container, we need to delete the ` server.pid ` file in ` /tmp/pids ` manually. So I added a docker entrypoint srcipt to delete that file everytime before the container start if  ` server.pid ` exist. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

# How Has This Been Tested?

I build the docker image in my local dev environment, then develop the project with that image. To test it, I firstly went to the container bash, make sure the ` server.pid ` file is in the right path then I restart the container several times and restart my PC to test if we still need to delete ` server.pid ` file manually. Also by monitoring the pids folder I can clearly see the file was removed then created when restart the container. 

- [x] restart container
- [x] reboot PC

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created or extended unit tests to address my new additions
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules