### PR TITLE
Fix a bug - unnecessary logs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,7 +74,8 @@ Doubtfire::Application.configure do
   config.action_controller.perform_caching = false
 
   # Logging level (:debug, :info, :warn, :error, :fatal)
-  config.log_level = :debug
+  config.log_level = :warn
+  
 
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin


### PR DESCRIPTION
# Description

Changed the log warning level to clear bunch of low-level logging information to cron tasks in doubtfire-api.

Fixes # Unnecessary logs

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Compared logging messages shown in api logs, before it shows bunches of 'Info' and 'Debug' level log messages, now they are not coming up any more.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

If you have any questions, please contact @macite or @jakerenzella.
