### PR TITLE
build: multi-platform Dockerfile and tex

### DIFF
--- a/.ci-setup/texlive-install.sh
+++ b/.ci-setup/texlive-install.sh
@@ -4,7 +4,7 @@ APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != 
 APP_PATH=`cd "$APP_PATH"; pwd`
 
 # See if there is a cached version of TL available
-export PATH=/tmp/texlive/bin/x86_64-linux:$PATH
+export PATH=/tmp/texlive/bin/`uname -m`-linux:$PATH
 if ! command -v lualatex > /dev/null; then
   # Obtain TeX Live
   wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1-buster
+FROM ruby:3.1-bullseye
 
 # DEBIAN_FRONTEND=noninteractive is required to install tzdata in non interactive way
 ENV DEBIAN_FRONTEND noninteractive
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y \
   libmariadb-dev \
   python3-pygments \
   tzdata \
-  wget
+  wget \
+  libc6-dev
 
 # Setup the folder where we will deploy the code
 WORKDIR /doubtfire


### PR DESCRIPTION
Updates the Ruby base image to support multi-arch image builds.

* Bullseye base image has glibc >= 2.9 to support nokigiri native gem.
* texlive install uses dir path from uname to always have correct path.

Note: I built the images with:  `docker buildx build --platform linux/amd64,linux/arm64 . -t jake/doubtfire-api-test`