### PR TITLE
fix: ignore locally installed gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config
 /.bundle
 
+# Ignore locally installed gems
+vendor/bundle/
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 
@@ -27,7 +30,7 @@ student-work/
 .env
 .env*
 
-# RubyMine files
+# IDE configs
 .idea/
 .byebug_history
 coverage/


### PR DESCRIPTION
# Description

Trivial change to ignore locally installed gems. Path specified is the default in bundle's help messages. This avoids having tens of thousands of untracked files if I use bundle to install the gems outside of a docker container.

## Type of change

Trivial config update.

# How Has This Been Tested?

`git` now ignores locally installed gems as intended.