### PR TITLE
ci: update service name to fix ci

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
             echo "Install mariadb"
             apt -y install mariadb-server mariadb-client
             echo "Run mariadb"
-            service mysql start
+            service mariadb start
             mysql -uroot -e "CREATE USER 'dfire'@'localhost' IDENTIFIED BY 'pwd'; GRANT ALL PRIVILEGES ON *.* TO 'dfire'@'localhost'; FLUSH PRIVILEGES;"
             echo "Setting up database"
             bundle exec rake db:populate


### PR DESCRIPTION
# Description

This fixes our long-broken CI and we can run automated unit tests with GitHub Actions again. The service is called `mariadb` now instead of `mysql`, so previously no tests are ran because the db wasn't even started.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Refer to this run:
https://github.com/ublefo/doubtfire-api/runs/7600928237?check_suite_focus=true
