### PR TITLE
ci: improve descriptions and switch to mariadb service container

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,30 +1,34 @@
-name: test-doubtfire-api
+name: Run Unit Tests
 on: [push,pull_request]
 jobs:
-  run-unit-tests:
+  unit-test-runner:
     runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb
+        env:
+          MARIADB_USER: dfire
+          MARIADB_PASSWORD: pwd
+          MARIADB_DATABASE: doubtfire-test
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: yes # This is required or the healthcheck script can't connect to the db
+        options: --health-cmd "/usr/local/bin/healthcheck.sh --connect --innodb_initialized" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Build base Doubtfire image
-        uses: docker/build-push-action@v2
+      - name: Build base doubtfire-api development image
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: false
           load: true
-          tags: doubtfire-core:local
-      - name: Create database and run rake tests
+          tags: doubtfire-api-development:local
+      - name: Populate database and run rake tests
         uses: addnab/docker-run-action@v3
         with:
-          image: doubtfire-core:local
-          options: -v ${{ github.workspace }}:/doubtfire -e RAILS_ENV=test -e DF_STUDENT_WORK_DIR=/student-work -e DF_INSTITUTION_HOST=http://localhost:3000 -e DF_INSTITUTION_PRODUCT_NAME=OnTrack -e DF_SECRET_KEY_BASE='test-secret-key-test-secret-key!' -e DF_SECRET_KEY_ATTR='test-secret-key-test-secret-key!' -e DF_SECRET_KEY_DEVISE='test-secret-key-test-secret-key!' -e DF_TEST_DB_ADAPTER=mysql2 -e DF_TEST_DB_HOST=localhost -e DF_TEST_DB_DATABASE=doubtfire-test -e DF_TEST_DB_USERNAME=dfire -e DF_TEST_DB_PASSWORD=pwd -e OVERSEER_ENABLED=0 -e DF_ENCRYPTION_PRIMARY_KEY=AMLOMYA5GV8B4fTK3VKMhVGn8WdvUW8g -e DF_ENCRYPTION_DETERMINISTIC_KEY=anlmuJ6cB3bN3biXRbYvmPsC5ALPFqGG -e DF_ENCRYPTION_KEY_DERIVATION_SALT=hzPR8D4qpOnAg7VeAhkhWw6JmmzKJB10
+          image: doubtfire-api-development:local
+          options: -v ${{ github.workspace }}:/doubtfire -e RAILS_ENV=test -e DF_STUDENT_WORK_DIR=/student-work -e DF_INSTITUTION_HOST=http://localhost:3000 -e DF_INSTITUTION_PRODUCT_NAME=OnTrack -e DF_SECRET_KEY_BASE='test-secret-key-test-secret-key!' -e DF_SECRET_KEY_ATTR='test-secret-key-test-secret-key!' -e DF_SECRET_KEY_DEVISE='test-secret-key-test-secret-key!' -e DF_TEST_DB_ADAPTER=mysql2 -e DF_TEST_DB_HOST=mariadb -e DF_TEST_DB_DATABASE=doubtfire-test -e DF_TEST_DB_USERNAME=dfire -e DF_TEST_DB_PASSWORD=pwd -e OVERSEER_ENABLED=0 -e DF_ENCRYPTION_PRIMARY_KEY=AMLOMYA5GV8B4fTK3VKMhVGn8WdvUW8g -e DF_ENCRYPTION_DETERMINISTIC_KEY=anlmuJ6cB3bN3biXRbYvmPsC5ALPFqGG -e DF_ENCRYPTION_KEY_DERIVATION_SALT=hzPR8D4qpOnAg7VeAhkhWw6JmmzKJB10
           run:  |
-            echo "Install mariadb"
-            apt -y install mariadb-server mariadb-client
-            echo "Run mariadb"
-            service mariadb start
-            mysql -uroot -e "CREATE USER 'dfire'@'localhost' IDENTIFIED BY 'pwd'; GRANT ALL PRIVILEGES ON *.* TO 'dfire'@'localhost'; FLUSH PRIVILEGES;"
-            echo "Setting up database"
+            echo "Populating database"
             bundle exec rake db:populate
             echo "Running rake tests"
             TERM=xterm bundle exec rails test


### PR DESCRIPTION
# Description

- Update some descriptions to make things easier to understand
- Migrate to use a mariadb service container to avoid having to install it in the app container
- Add heathchecks to ensure db is ready before anything else happens

## Type of change

Minor improvements and restructuring.

# How Has This Been Tested?

Refer to this run:
https://github.com/ublefo/doubtfire-api/runs/7603679827?check_suite_focus=true

