### PR TITLE
enhance: refactor texlive installation script

### DIFF
--- a/.ci-setup/texlive-install.sh
+++ b/.ci-setup/texlive-install.sh
@@ -1,24 +1,27 @@
-#!/bin/sh
+#!/bin/bash
 
-APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
-APP_PATH=`cd "$APP_PATH"; pwd`
+set -e
+APP_PATH="$(readlink -f "$(dirname "$0")")"
+TEX_COMPILER=lualatex
 
 # See if there is a cached version of TL available
-export PATH=/tmp/texlive/bin/`uname -m`-linux:$PATH
-if ! command -v lualatex > /dev/null; then
-  # Obtain TeX Live
-  wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+# shellcheck disable=SC2155
+export PATH="/tmp/texlive/bin/$(uname -m)-linux:$PATH"
+if ! command -v "$TEX_COMPILER" > /dev/null; then
+  echo "----------------------------------------"
+  echo "Downloading texlive installer archive from CTAN:"
+  wget https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
   tar -xzf install-tl-unx.tar.gz
   cd install-tl-20*
 
-  echo "Installing using profile:"
-  cat ${APP_PATH}/texlive.profile
-
+  echo "----------------------------------------"
+  echo "Installing texlive using profile:"
+  cat "${APP_PATH}"/texlive.profile
   echo
-
-  # Install a full texlive system
   ./install-tl --profile="${APP_PATH}/texlive.profile"
 
+  echo "----------------------------------------"
+  echo "Installing additional texlive packages:"
   tlmgr install fontawesome luatextra luacode minted fvextra catchfile xstring framed lastpage
 
   cd ..
@@ -26,3 +29,9 @@ if ! command -v lualatex > /dev/null; then
   # Keep no backups (not required, simply makes cache bigger)
   tlmgr option -- autobackup 0
 fi
+
+echo "----------------------------------------"
+echo "Installation complete, verifying installation of $TEX_COMPILER."
+command -v "$TEX_COMPILER" >/dev/null 2>&1 || { echo >&2 "$TEX_COMPILER is not found."; exit 1; }
+# Do a test compile recommended by https://www.tug.org/texlive/quickinstall.html
+"$TEX_COMPILER" small2e || { echo >&2 "Failed to process test file with $TEX_COMPILER."; exit 1; }


### PR DESCRIPTION
# Description

Overall changes:
- quote variables that should be quoted to increase robustness
- switch to `$(command)` instead of `` `command` `` as suggested by shellcheck
- improve readability of output messages by adding some separators

Area-specific changes:
- use `set -e` to make sure any failed command will produce a failure
- refactor `APP_PATH` logic
- add `TEX_COMPILER` for testing the specific tex compiler we are using
- switch to HTTPS instead of relying on protocol upgrade redirects
- add final checks to test `TEX_COMPILER`'s existence and compile a test  document

# Type of change

Minor enhancement to improve reliability.

# How Has This Been Tested?

https://github.com/ublefo/doubtfire-api/runs/7617634785?check_suite_focus=true

