### PR TITLE
chore: refactor workflow manifest and split steps

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,24 @@
 name: Run Unit Tests
-on: [push,pull_request]
+on: [push, pull_request]
+
+env:
+  RAILS_ENV: "test"
+  DF_STUDENT_WORK_DIR: "/student-work"
+  DF_INSTITUTION_HOST: "http://localhost:3000"
+  DF_INSTITUTION_PRODUCT_NAME: "OnTrack"
+  DF_SECRET_KEY_BASE: "test-secret-key-test-secret-key!"
+  DF_SECRET_KEY_ATTR: "test-secret-key-test-secret-key!"
+  DF_SECRET_KEY_DEVISE: "test-secret-key-test-secret-key!"
+  DF_TEST_DB_ADAPTER: "mysql2"
+  DF_TEST_DB_HOST: "mariadb"
+  DF_TEST_DB_DATABASE: "doubtfire-test"
+  DF_TEST_DB_USERNAME: "dfire"
+  DF_TEST_DB_PASSWORD: "pwd"
+  OVERSEER_ENABLED: "0"
+  DF_ENCRYPTION_PRIMARY_KEY: "AMLOMYA5GV8B4fTK3VKMhVGn8WdvUW8g"
+  DF_ENCRYPTION_DETERMINISTIC_KEY: "anlmuJ6cB3bN3biXRbYvmPsC5ALPFqGG"
+  DF_ENCRYPTION_KEY_DERIVATION_SALT: "hzPR8D4qpOnAg7VeAhkhWw6JmmzKJB10"
+
 jobs:
   unit-test-runner:
     runs-on: ubuntu-latest
@@ -7,14 +26,14 @@ jobs:
       mariadb:
         image: mariadb
         env:
-          MARIADB_USER: dfire
-          MARIADB_PASSWORD: pwd
-          MARIADB_DATABASE: doubtfire-test
+          MARIADB_USER: ${{ env.DF_TEST_DB_USERNAME }}
+          MARIADB_PASSWORD: ${{ env.DF_TEST_DB_PASSWORD }}
+          MARIADB_DATABASE: ${{ env.DF_TEST_DB_DATABASE }}
           MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: yes # This is required or the healthcheck script can't connect to the db
         options: --health-cmd "/usr/local/bin/healthcheck.sh --connect --innodb_initialized" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build base doubtfire-api development image
         uses: docker/build-push-action@v3
         with:
@@ -22,13 +41,49 @@ jobs:
           push: false
           load: true
           tags: doubtfire-api-development:local
-      - name: Populate database and run rake tests
+      - name: Populate database
         uses: addnab/docker-run-action@v3
         with:
           image: doubtfire-api-development:local
-          options: -v ${{ github.workspace }}:/doubtfire -e RAILS_ENV=test -e DF_STUDENT_WORK_DIR=/student-work -e DF_INSTITUTION_HOST=http://localhost:3000 -e DF_INSTITUTION_PRODUCT_NAME=OnTrack -e DF_SECRET_KEY_BASE='test-secret-key-test-secret-key!' -e DF_SECRET_KEY_ATTR='test-secret-key-test-secret-key!' -e DF_SECRET_KEY_DEVISE='test-secret-key-test-secret-key!' -e DF_TEST_DB_ADAPTER=mysql2 -e DF_TEST_DB_HOST=mariadb -e DF_TEST_DB_DATABASE=doubtfire-test -e DF_TEST_DB_USERNAME=dfire -e DF_TEST_DB_PASSWORD=pwd -e OVERSEER_ENABLED=0 -e DF_ENCRYPTION_PRIMARY_KEY=AMLOMYA5GV8B4fTK3VKMhVGn8WdvUW8g -e DF_ENCRYPTION_DETERMINISTIC_KEY=anlmuJ6cB3bN3biXRbYvmPsC5ALPFqGG -e DF_ENCRYPTION_KEY_DERIVATION_SALT=hzPR8D4qpOnAg7VeAhkhWw6JmmzKJB10
-          run:  |
-            echo "Populating database"
-            bundle exec rake db:populate
-            echo "Running rake tests"
-            TERM=xterm bundle exec rails test
+          options: >
+            -v ${{ github.workspace }}:/doubtfire
+            -e RAILS_ENV
+            -e DF_STUDENT_WORK_DIR
+            -e DF_INSTITUTION_HOST
+            -e DF_INSTITUTION_PRODUCT_NAME
+            -e DF_SECRET_KEY_BASE
+            -e DF_SECRET_KEY_ATTR
+            -e DF_SECRET_KEY_DEVISE
+            -e DF_TEST_DB_ADAPTER
+            -e DF_TEST_DB_HOST
+            -e DF_TEST_DB_DATABASE
+            -e DF_TEST_DB_USERNAME
+            -e DF_TEST_DB_PASSWORD
+            -e OVERSEER_ENABLED
+            -e DF_ENCRYPTION_PRIMARY_KEY
+            -e DF_ENCRYPTION_DETERMINISTIC_KEY
+            -e DF_ENCRYPTION_KEY_DERIVATION_SALT
+          run: bundle exec rake db:populate
+      - name: Run rake tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: doubtfire-api-development:local
+          options: >
+            -v ${{ github.workspace }}:/doubtfire
+            -e RAILS_ENV
+            -e DF_STUDENT_WORK_DIR
+            -e DF_INSTITUTION_HOST
+            -e DF_INSTITUTION_PRODUCT_NAME
+            -e DF_SECRET_KEY_BASE
+            -e DF_SECRET_KEY_ATTR
+            -e DF_SECRET_KEY_DEVISE
+            -e DF_TEST_DB_ADAPTER
+            -e DF_TEST_DB_HOST
+            -e DF_TEST_DB_DATABASE
+            -e DF_TEST_DB_USERNAME
+            -e DF_TEST_DB_PASSWORD
+            -e OVERSEER_ENABLED
+            -e DF_ENCRYPTION_PRIMARY_KEY
+            -e DF_ENCRYPTION_DETERMINISTIC_KEY
+            -e DF_ENCRYPTION_KEY_DERIVATION_SALT
+          run: TERM=xterm bundle exec rails test


### PR DESCRIPTION
Some minor refactoring for the workflow manifest to improve robustness, and prepare for the upcoming additional jobs that run on arm64 that I plan to implement.

- Refactor the terrifyingly long line of environment variables and ensure we have a single source of truth
- Split db populate and unit test task into separate steps

https://github.com/ublefo/doubtfire-api/runs/7620273639?check_suite_focus=true
