### PR TITLE
fix: preserve links in PDF

### DIFF
--- a/.ci-setup/newpax.lua.patch
+++ b/.ci-setup/newpax.lua.patch
@@ -1,0 +1,11 @@
+--- /tmp/texlive/texmf-dist/tex/latex/newpax/newpax.lua
++++ /tmp/texlive/texmf-dist/tex/latex/newpax/newpax.lua
+@@ -206,7 +206,7 @@
+ -- XXXXXX encode/escape the file name?
+ local function outputENTRY_file (file, pdfedoc)
+   local bytes       = GETSIZE(pdfedoc)
+-  local date        = GETINFO(pdfedoc).CreationDate
++  local date        = GETINFO(pdfedoc).CreationDate or "D:22222222222222"
+   -- file
+   local a = strENTRY_BEG
+   a = a .. strCMD_BEG .. constCMD_FILE .. strCMD_END

--- a/.ci-setup/texlive-install.sh
+++ b/.ci-setup/texlive-install.sh
@@ -22,7 +22,20 @@ if ! command -v "$TEX_COMPILER" > /dev/null; then
 
   echo "----------------------------------------"
   echo "Installing additional texlive packages:"
-  tlmgr install fontawesome luatextra luacode minted fvextra catchfile xstring framed lastpage
+  tlmgr install fontawesome luatextra luacode minted fvextra catchfile xstring framed lastpage pdfmanagement-testphase newpax
+
+  echo "----------------------------------------"
+  echo "Patching the newpax package version 0.52 to fix a bug:"
+  if NEWPAX_VERSION=$(tlmgr info --only-installed --data cat-version newpax) ; then
+    if [ "$NEWPAX_VERSION" == "0.52" ]; then
+      echo "Version 0.52 found, patching."
+      patch -d / -p0 < "${APP_PATH}"/newpax.lua.patch
+    else
+      echo "Version $NEWPAX_VERSION found, skipping the patch."
+    fi
+  else
+      echo >&2 "Package newpax not found!"; exit 1;
+  fi
 
   cd ..
 

--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -221,9 +221,14 @@ module FileHelper
 
   def compress_pdf(path, max_size = 2_500_000)
     # trusting path... as it needs to be replaced
-    logger.debug "Compressing PDF #{path} (#{File.size?(path)} bytes) using GhostScript"
     # only compress things over max_size -- defaults to 2.5mb
-    return if File.size?(path) < max_size
+    current_filesize = File.size?(path)
+    if current_filesize < max_size
+      logger.debug "PDF #{path} (#{current_filesize} bytes) is smaller than #{max_size}, skipping compression."
+      return
+    else
+      logger.debug "Compressing PDF #{path} (#{current_filesize} bytes) using GhostScript"
+    end
 
     begin
       tmp_file = File.join(Dir.tmpdir, 'doubtfire', 'compress', "#{File.dirname(path).split(File::Separator).last}-file.pdf")

--- a/app/views/layouts/application.pdf.erbtex
+++ b/app/views/layouts/application.pdf.erbtex
@@ -1,4 +1,5 @@
 <% @latex_config={ :recipe => [ {:command => "lualatex",:runs => 2} ] } %>
+\DocumentMetadata{uncompress}
 \documentclass[11pt,a4paper]{article}
 \usepackage[T1]{fontenc}
 \usepackage{textcomp}
@@ -23,6 +24,11 @@
   filecolor=black,
   urlcolor=blue,
   citecolor=black}
+
+\usepackage{newpax}
+\newpaxsetup{usefileattributes=true, addannots=true}
+\directlua{require("newpax")}
+<%= yield :preamble_newpax %>
 
 \epstopdfDeclareGraphicsRule{.tif}{png}{.png}{convert #1 \OutputFile}
 \AppendGraphicsExtensions{.tif}

--- a/app/views/portfolio/portfolio_pdf.pdf.erb
+++ b/app/views/portfolio/portfolio_pdf.pdf.erb
@@ -27,10 +27,15 @@ end
 def task_for_def(td)
   task_for_def_id(td.id)
 end
+
+# array to hold the list of PDF paths we are inserting for annotation extraction with newpax
+document_list = Array.new
 %>
 
 \begin{titlepage}
   <% if @learning_summary_report %>
+    % add learning summary report to the document list for annotation extraction
+    <% document_list.append(@learning_summary_report)%>
     \includepdf[addtotoc={\thepage,section,1,Learning Summary Report,chap:learningsummary},pages={1-}]{<%= @learning_summary_report %>}
   <% end %>
 
@@ -177,6 +182,12 @@ No Tutor
     \phantomsection
     \label{additional_file_<%= f[:idx] %>}
     \addcontentsline{toc}{subsection}{<%= lesc f[:name] %>}
+
+    % add additional PDF files to the document list for annotation extraction
+    <% if f[:kind] == "document" %>
+         <% document_list.append(@project.portfolio_tmp_file_path(f)) %>
+    <% end %>
+
     <%= render partial:"shared/file", locals: {idx: f[:idx] - 1, count: @files.count - 1, name: f[:name], base_path: @base_path, file_name: @project.portfolio_tmp_file_path(f), file_type: f[:kind]} %>
   <% end %>
 <% end %>
@@ -217,6 +228,19 @@ No Tutor
     \end{tabular}
   <% end %>
   <% if File.exists? task.portfolio_evidence_path %>
+    % add task evidence to the document list for annotation extraction
+    <% document_list.append(task.portfolio_evidence_path)%>
     \includepdf[pages={1-}]{<%= task.portfolio_evidence_path %>}
   <% end %>
+<% end %>
+
+% generate lua calls for newpax and insert it in the preamble for annotation extraction
+<% content_for :preamble_newpax do %>
+  \directlua
+  {
+  <% document_list.each do |path| %>
+    % newpax does not allow the .pdf file extension, file paths must be supplied without extension
+    newpax.writenewpax("<%= File.join(File.dirname(path), File.basename(path, File.extname(path))) %>")
+  <% end %>
+  }
 <% end %>

--- a/app/views/task/task_pdf.pdf.erb
+++ b/app/views/task/task_pdf.pdf.erb
@@ -93,6 +93,9 @@ No Tutor % Supervisor's Name
 
 \pagestyle{body}
 
+% array to hold the list of PDF paths we are inserting for annotation extraction with newpax
+<% document_list = Array.new %>
+
 <% @files.each_with_index do |file, idx| %>
   <%  if file != @files.first %>
   \clearpage
@@ -111,8 +114,21 @@ No Tutor % Supervisor's Name
   <% end %>
 
   <% if file[:type] == 'document' %>
+    % add document paths to document_list to generate lua calls to newpax later
+    <% document_list.append(file[:path])%>
     \includepdf[pages={1-}]{<%= file[:path] %>}
   <% end %>
+<% end %>
+
+% generate lua calls for newpax and insert it in the preamble for annotation extraction
+<% content_for :preamble_newpax do %>
+  \directlua
+  {
+  <% document_list.each do |path| %>
+    % newpax does not allow the .pdf file extension, file paths must be supplied without extension
+    newpax.writenewpax("<%= File.join(File.dirname(path), File.basename(path, File.extname(path))) %>")
+  <% end %>
+  }
 <% end %>
 
  % section hello_world (end) Hello World


### PR DESCRIPTION
# Description

This fix will only preserve **links** (hyperlinks and internal links) and nothing else. This is a limitation of the TeX packages we have available, both `pax` and `newpax` can only extract links and nothing else. The TeX engine _can_ insert annotations with a package like `pdfcomment`, but we cannot extract them from the PDFs we are including, so this is as good as it gets right now.

# Changes made

- [x] Update erb templates
    - Global preamble `app/views/layouts/application.pdf.erbtex`
    - Task submission PDF template `app/views/task/task_pdf.pdf.erb`
    - Portfolio PDF template `app/views/portfolio/portfolio_pdf.pdf.erb`
- [x] Update installation script to install `newpax` with `tlmgr`
- [x] Update installation script to patch the current version of `newpax` (call `tlmgr info --only-installed --data cat-version newpax` and ensure we are only patching v0.52)

- [x] Improve logging in `app/helpers/file_helper.rb` to report whether PDF compression has happened or not

Fixes:  https://github.com/doubtfire-lms/doubtfire-api/issues/130 and https://github.com/doubtfire-lms/doubtfire-web/issues/337
Does **not** fix: https://github.com/doubtfire-lms/doubtfire-api/issues/326

# Tests done
CI run:
https://github.com/ublefo/doubtfire-api/runs/7643617478?check_suite_focus=true

Additional tests done locally:
- Submitted a [test file](https://commons.wikimedia.org/wiki/File:Ghostscript_annotations.pdf) as task evidence, learning summary and additional portfolio evidence, ensured links are present in the output file. Only the links on the first page should be intact, we currently cannot preserve anything in the other pages.
- Ensured our GhostScript compression calls will preserve these links (ImageMagick doesn't seem to have such options) by running GhostScript with the same cmdline args specified in `file_helper` and made sure links are still present after processing.

