### PR TITLE
chore: stop relying on a third party site for logo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-![Doubtfire Logo](http://puu.sh/lyClF/fde5bfbbe7.png)
+![Doubtfire Logo](https://github.com/doubtfire-lms/doubtfire-web/raw/6.2.x/src/assets/icons/android-chrome-192x192.png)
 
 # Contributing to Doubtfire Api
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Doubtfire Logo](http://puu.sh/lyClF/fde5bfbbe7.png)
+![Doubtfire Logo](https://github.com/doubtfire-lms/doubtfire-web/raw/6.2.x/src/assets/icons/android-chrome-192x192.png)
 
 # Doubtfire API  [![test-doubtfire-api](https://github.com/doubtfire-lms/doubtfire-api/actions/workflows/push.yml/badge.svg)](https://github.com/doubtfire-lms/doubtfire-api/actions/workflows/push.yml)
 


### PR DESCRIPTION
# Description

Remove the reliance on a random 3rd party site for project logo. If you load this file in an editor that previews markdown, it sends out an unencrypted HTTP request and relies on a redirect for protocol upgrade which could potentially be insecure. We could change it to HTTPS, but it's better to just use our current logo in the repo instead.

# How Has This Been Tested?

There are no code changes.