### PR TITLE
fix: correct the bad tag in email template for the "due soon" ul

### DIFF
--- a/app/views/notifications_mailer/weekly_student_summary.html.erb
+++ b/app/views/notifications_mailer/weekly_student_summary.html.erb
@@ -81,7 +81,7 @@
     <p>Work to get the following task<%="s" if @soon_top.count > 1%> done, as these are <b>due</b> soon!</p>
     <ul>
 <%          @soon_top.each do |st| %>
-        </li><%= top_task_desc(st) %></li>
+        <li><%= top_task_desc(st) %></li>
 <%          end %>
     </ul>
 <%      end %>


### PR DESCRIPTION
Correct the bad tag in email template for the "due soon" list. 
Minor template change to fix a cosmetic issue.

Fixes #137

