### PR TITLE
enhance: reduce logging verbosity for generate_pdfs in production

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,6 +82,9 @@ Doubtfire::Application.configure do
   # Set deterministic randomness, source: https://github.com/stympy/faker#deterministic-random
   Faker::Config.random = Random.new(77)
 
+  # pdfgen log verbosity
+  config.pdfgen_quiet = false
+
   require_relative 'doubtfire_logger'
   config.logger = DoubtfireLogger.logger
   Rails.logger = DoubtfireLogger.logger

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,9 @@ Doubtfire::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
+  # pdfgen log verbosity
+  config.pdfgen_quiet = true
+
   require_relative 'doubtfire_logger'
   config.logger = DoubtfireLogger.logger
   Rails.logger = DoubtfireLogger.logger

--- a/lib/tasks/generate_pdfs.rake
+++ b/lib/tasks/generate_pdfs.rake
@@ -38,6 +38,9 @@ namespace :submission do
   end
 
   task generate_pdfs: :environment do
+    # Reduce logging verbosity for the generate_pdfs task in production
+    logger.level = :warn if Rails.configuration.pdfgen_quiet
+
     if is_executing?
       logger.error 'Skip generate pdf -- already executing'
       puts 'Skip generate pdf -- already executing'


### PR DESCRIPTION
Introduce a new config in the environment so we can set logging verbosity for the `generate_pdfs` task to `:warn`. This way successful PDF generation runs should not generate any new logs in production.

Fixes #367