### PR TITLE
Perform automatic PDF repair with qpdf on task submissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:3.1-bullseye
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \
   ffmpeg \
-  ghostscript \
+  ghostscript qpdf \
   imagemagick \
   libmagic-dev \
   libmagickwand-dev \

--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -273,6 +273,14 @@ module FileHelper
     FileUtils.rm tmp_file if File.exist? tmp_file
   end
 
+  def qpdf(path)
+    exec = "qpdf \"#{path}\" --replace-input >>/dev/null 2>>/dev/null"
+    logger.debug "Running QPDF on: #{path}"
+    system_try_within 30, "Failed running QPDF on #{path}", exec
+  rescue => e
+    logger.error "Failed to run QPDF on #{path}. Rescued with error:\n\t#{e.message}"
+  end
+
   #
   # Move files between stages - new -> in process -> done
   #
@@ -513,6 +521,7 @@ module FileHelper
   module_function :comment_reply_prompt_path
   module_function :compress_image_to_dest
   module_function :compress_pdf
+  module_function :qpdf
   module_function :move_files
   module_function :pdf_valid?
   module_function :copy_pdf

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -991,6 +991,12 @@ class Task < ApplicationRecord
     end
 
     def make_pdf
+      logger.debug "Running QPDF on all documents before rendering to repair any potential broken files."
+      @files.each do |f|
+        if f[:type] == "document"
+          FileHelper.qpdf(f[:path])
+        end
+      end
       render_to_string(template: '/task/task_pdf', layout: true)
     end
   end

--- a/deployAppSvr.Dockerfile
+++ b/deployAppSvr.Dockerfile
@@ -7,7 +7,7 @@ FROM ruby:3.1-buster
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
   ffmpeg \
-  ghostscript \
+  ghostscript qpdf \
   imagemagick \
   libmagic-dev \
   libmagickwand-dev \


### PR DESCRIPTION
## Description

Turnitin's originality report PDFs all seem to have broken xref tables, and this makes it impossible for students to submit originality reports from Turnitin. The tex compiler really doesn't like PDFs with broken xref tables and will fail if you use `\includepdf` on such a file. Most PDF readers will silently ignore or repair this on the fly so it's hard to detect unless you know what to look for. `exiftool` is a tool that can catch this. Some fields in the following output have been redacted for privacy reasons.

```
$ exiftool turnitin-report.pdf 
======== turnitin-report.pdf
ExifTool Version Number         : 12.42
File Name                       : turnitin-report.pdf
Directory                       : .
File Size                       : 1000 kB
File Modification Date/Time     : 
File Access Date/Time           : 
File Inode Change Date/Time     : 
File Permissions                : -rw-r--r--
File Type                       : PDF
File Type Extension             : pdf
MIME Type                       : application/pdf
PDF Version                     : 1.4
Linearized                      : No
Warning                         : Invalid xref table

$ qpdf turnitin-report.pdf fixed.pdf
WARNING: turnitin-report.pdf: file is damaged
WARNING: turnitin-report.pdf: can't find startxref
WARNING: turnitin-report.pdf: Attempting to reconstruct cross-reference table
qpdf: operation succeeded with warnings; resulting file may have some problems

$ exiftool fixed.pdf
======== fixed.pdf
ExifTool Version Number         : 12.42
File Name                       : fixed.pdf
Directory                       : .
File Size                       : 1000 kB
File Modification Date/Time     : 
File Access Date/Time           : 
File Inode Change Date/Time     : 
File Permissions                : -rw-r--r--
File Type                       : PDF
File Type Extension             : pdf
MIME Type                       : application/pdf
PDF Version                     : 1.4
Linearized                      : No
Create Date                     : 
Creator                         : Chromium
Modify Date                     : 
Producer                        : Skia/PDF m88
Page Count                      : 11
    2 image files read
```


To increase the robustness of our PDF processing pipeline, we can simply pass all submitted PDFs through `qpdf` without any arguments in the PDF processing pipeline, and `qpdf` will automatically repair the file if it has a broken xref table. 

According to the documentation, when running `qpdf` with no options, the output file is functionally identical to the input file but may be structurally reorganized, and orphaned objects are removed from the file.

https://stackoverflow.com/a/46501105
https://qpdf.readthedocs.io/en/stable/cli.html#basic-invocation

Note: the additional portfolio evidence part is not covered (as it's rarely used) and it will be implemented at a later date.

## Tests done

- [x] Unit tests (wait for CI)
- [x] Manual submission of known-problematic files