### PR TITLE
fix: address potential csrf vuln

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :exception
 
   # private
 


### PR DESCRIPTION
Address a potential CSRF vuln. More details here: https://www.veracode.com/blog/managing-appsec/when-rails-protectfromforgery-fails

This has also been the new default for rails for a while now, so we should probably follow it too.