### PR TITLE
fix: hard-code date in newpax to avoid nil dates

### DIFF
--- a/.ci-setup/newpax.lua.patch
+++ b/.ci-setup/newpax.lua.patch
@@ -5,7 +5,7 @@
  local function outputENTRY_file (file, pdfedoc)
    local bytes       = GETSIZE(pdfedoc)
 -  local date        = GETINFO(pdfedoc).CreationDate
-+  local date        = GETINFO(pdfedoc).CreationDate or "D:22222222222222"
++  local date        = "D:22222222222222"
    -- file
    local a = strENTRY_BEG
    a = a .. strCMD_BEG .. constCMD_FILE .. strCMD_END


### PR DESCRIPTION
Students have been reporting higher error rates after newpax has been introduced due to the fact that it can't cope with nonexistent creation date in the PDF metadata. Fix this by hard-coding the date for now as an emergency fix, and we will look into addressing this properly later on.