### PR TITLE
fix: ensure portfolio PDFs are compressed

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -943,6 +943,8 @@ class Project < ApplicationRecord
         fout.puts pdf_text
       end
 
+      FileHelper.compress_pdf(portfolio_path)
+
       logger.info "Created portfolio at #{portfolio_path} - #{log_details}"
 
       self.portfolio_production_date = Time.zone.now


### PR DESCRIPTION
This pull request fixes an urgent issue resulting in large portfolio file sizes.

Use of new pax is resulting in portfolios that are 10x their normal size. Compressing after creation fixes this until the issue with the use of new pax can be resolved.