### PR TITLE
feat: pull overseer docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,18 @@ RUN apt-get update && apt-get install -y \
   python3-pygments \
   tzdata \
   wget \
-  libc6-dev
+  libc6-dev \
+  apt-transport-https \
+  ca-certificates \
+  curl \
+  gnupg2 \
+  software-properties-common
+
+# docker-ce-cli apt dependencies
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN add-apt-repository "deb [arch=amd64,arm64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+RUN apt-get update
+RUN apt-get -y install docker-ce docker-ce-cli containerd.io
 
 # Setup the folder where we will deploy the code
 WORKDIR /doubtfire

--- a/app/api/admin/overseer_admin_api.rb
+++ b/app/api/admin/overseer_admin_api.rb
@@ -88,5 +88,20 @@ module Admin
         present [], with: Grape::Presenters::Presenter
       end
     end
+
+    desc 'Get overseer image by id and pull image'
+    put '/admin/overseer_images/:id/pull_image' do
+      unless authorise? current_user, User, :admin_overseer
+        error!({ error: 'Not authorised to pull an overseer image' }, 403)
+      end
+      unless Doubtfire::Application.config.overseer_enabled
+        error!({ error: 'Overseer is not enabled. Enable Overseer before updating settings.' }, 403)
+      end
+
+      overseer_image = OverseerImage.find(params[:id])
+      overseer_image.pull_from_docker
+
+      present overseer_image, with: Entities::OverseerImageEntity
+    end
   end
 end

--- a/app/api/entities/overseer_image_entity.rb
+++ b/app/api/entities/overseer_image_entity.rb
@@ -3,5 +3,8 @@ module Entities
     expose :id
     expose :name
     expose :tag
+    expose :pulled_image_status
+    expose :last_pulled_date
+    expose :pulled_image_text
   end
 end

--- a/app/models/overseer_image.rb
+++ b/app/models/overseer_image.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 class OverseerImage < ApplicationRecord
   # Callbacks - methods called are private
   before_destroy :can_destroy?
@@ -8,7 +10,32 @@ class OverseerImage < ApplicationRecord
   # Always add a unique index with uniqueness constraint
   # This is to prevent new records from passing the validations when checked at the same time before being written
   validates :name,  presence: true, uniqueness: true
-  validates :tag,   presence: true, uniqueness: true
+  validates :tag,   presence: true, uniqueness: true, format: { with: /\A([\w.\-_]+((?::\d+|)(?=\/[a-z0-9._-]+\/[a-z0-9._-]+))|)(?:\/|)([a-z0-9.\-_]+(?:\/[a-z0-9.\-_]+|))(:([\w.\-_]{1,127})|)\z/ }
+
+  enum pulled_image_status: { failed: 0, success: 1 }
+
+  # Pulls overseer image
+  def pull_from_docker
+    unless valid?
+      return false
+    end
+
+    #TODO: add global repository ... #{global_registry_setting}#{tag}... so you can add a global registry without it being added to the tag name
+    self.last_pulled_date = Time.zone.now
+    cmd = "docker pull #{tag}"
+    out_text, error_text, exit_status = Open3.capture3(cmd)
+    self.pulled_image_text = "#{cmd}\n#{out_text}\n#{error_text}"
+
+    if (exit_status != 0)
+      self.pulled_image_status = :failed
+    else 
+      self.pulled_image_status = :success
+    end
+
+    logger.debug self.pulled_image_text
+
+    self.save
+  end
 
   private
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -182,6 +182,12 @@ module Doubtfire
       config.overseer_images = YAML.load_file(Rails.root.join('config/overseer-images.yml')).with_indifferent_access
       config.has_overseer_image = ->(key) { config.overseer_images['images'].any? { |img| img[:name] == key } }
 
+      docker_config = {
+        DOCKER_PROXY_URL: ENV['DOCKER_PROXY_URL'],
+        DOCKER_TOKEN: ENV['DOCKER_TOKEN'],
+        DOCKER_USER: ENV['DOCKER_USER']
+      }
+
       publisher_config = {
         RABBITMQ_HOSTNAME: ENV['RABBITMQ_HOSTNAME'],
         RABBITMQ_USERNAME: ENV['RABBITMQ_USERNAME'],
@@ -207,6 +213,11 @@ module Doubtfire
         # This is enough for now:
         DEFAULT_BINDING_KEY: '*.result'
       }
+
+      if docker_config[:DOCKER_TOKEN] && docker_config[:DOCKER_PROXY_URL]
+        puts "Logging into docker proxy"
+        `echo \"${DOCKER_TOKEN}\" | docker login --username ${DOCKER_USER} --password-stdin ${DOCKER_PROXY_URL}`
+      end
 
       config.sm_instance = ServicesManager.instance
       config.sm_instance.register_client(:ontrack, publisher_config, subscriber_config)

--- a/db/migrate/20230206021556_add_columns_to_overseer_images.rb
+++ b/db/migrate/20230206021556_add_columns_to_overseer_images.rb
@@ -1,0 +1,7 @@
+class AddColumnsToOverseerImages < ActiveRecord::Migration[7.0]
+  def change
+    add_column :overseer_images, :pulled_image_text, :text
+    add_column :overseer_images, :pulled_image_status, :integer
+    add_column :overseer_images, :last_pulled_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_17_123038) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_06_021556) do
   create_table "activity_types", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation", null: false
@@ -155,6 +155,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_17_123038) do
     t.string "tag", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "pulled_image_text"
+    t.integer "pulled_image_status"
+    t.datetime "last_pulled_date"
   end
 
   create_table "plagiarism_match_links", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/test/models/overseer_image_test.rb
+++ b/test/models/overseer_image_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class OverseerImageTest < ActiveSupport::TestCase
+
+  def test_valid
+    oi = OverseerImage.create(
+      name: 'Image',
+      tag: 'image'
+    )
+
+    assert oi.valid?
+  end
+
+  def test_valid_with_example
+    oi = OverseerImage.create(
+      name: 'Image',
+      tag: 'macite/overseer-dotnet:test'
+    )
+
+    assert oi.valid?, oi.errors
+  end
+
+  def test_cannot_pull_invalid_tag
+    oi = OverseerImage.create(
+      name: 'Image',
+      tag: 'image & ls'
+    )
+
+    refute oi.valid?
+    # pull from docker, will refuse as invalid
+    refute oi.pull_from_docker
+  end
+
+  def test_cannot_inject_code_in_tag
+    oi = OverseerImage.create(
+      name: 'Image',
+      tag: 'image & ls'
+    )
+
+    refute oi.valid?
+
+    oi.tag = 'image&ls'
+    refute oi.valid?
+
+    oi.tag = 'image|ls'
+    refute oi.valid?
+
+    oi.tag = 'image>ls'
+    refute oi.valid?
+
+    oi.tag = 'image<ls'
+    refute oi.valid?
+
+    oi.tag = 'image($ls)'
+    refute oi.valid?
+
+    oi.tag = 'image$ls'
+    refute oi.valid?
+  end
+end


### PR DESCRIPTION
# Description

Added the ability to pull a Docker image. To be used for pulling Overseer images from the front end. This new feature has required the installation of Docker in the doubtfire-api container, which is included in this commit.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This was tested through the test file 'overseer_image_test' where the validity of a tag is checked for accuracy, including testing if the tag can be injected with code.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created or extended unit tests to address my new additions
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules