### PR TITLE
fix: exclude tasks from withdrawn units in webcal feed

### DIFF
--- a/app/models/webcal.rb
+++ b/app/models/webcal.rb
@@ -30,7 +30,7 @@ class Webcal < ApplicationRecord
       .joins(:unit, unit: :projects)
       .includes(:unit, unit: :projects)
       .where(
-        projects: { user_id: user_id },
+        projects: { user_id: user_id, enrolled: true },
         units: { active: true }
       )
       .where.not(


### PR DESCRIPTION
If a student withdraws from a unit, tasks will still show up in the webcal feed, because we did not delete the project. This fixes the oversight and excludes tasks from withdrawn units.