### PR TITLE
fix: change_task_comment_fail

### DIFF
--- a/.ci-setup/texlive-install.sh
+++ b/.ci-setup/texlive-install.sh
@@ -28,7 +28,7 @@ if ! command -v "$TEX_COMPILER" > /dev/null; then
 
   echo "----------------------------------------"
   echo "Installing additional texlive packages:"
-  tlmgr install fontawesome luatextra luacode minted fvextra catchfile xstring framed lastpage pdfmanagement-testphase newpax tcolorbox environ pdfcol tikzfill markdown paralist csvsimple gobble
+  tlmgr install fontawesome luatextra luacode minted fvextra catchfile xstring framed lastpage pdfmanagement-testphase newpax tcolorbox environ pdfcol tikzfill markdown paralist csvsimple gobble upquote
 
   echo "----------------------------------------"
   echo "Ensuring the newpax package is sufficiently up to date:"

--- a/db/migrate/20231201000245_fail_status_change.rb
+++ b/db/migrate/20231201000245_fail_status_change.rb
@@ -1,0 +1,11 @@
+class FailStatusChange < ActiveRecord::Migration[7.0]
+  def up
+    TaskStatus.where(name: "Fail").update_all(name: "Needs Improvement")
+    TaskStatusComment.where(comment: "Fail").update_all(comment: "Needs Improvement")
+  end
+
+  def down
+    TaskStatus.where(name: "Needs Improvement").update_all(name: "Fail")
+    TaskStatusComment.where(comment: "Needs Improvement").update_all(comment: "Fail")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
-  create_table "activity_types", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2023_12_01_000245) do
+  create_table "activity_types", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation", null: false
     t.datetime "created_at", null: false
@@ -20,21 +20,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["name"], name: "index_activity_types_on_name", unique: true
   end
 
-  create_table "auth_tokens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "auth_tokens", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "auth_token_expiry", null: false
     t.bigint "user_id"
     t.string "authentication_token", null: false
     t.index ["user_id"], name: "index_auth_tokens_on_user_id"
   end
 
-  create_table "breaks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "breaks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "start_date", null: false
     t.integer "number_of_weeks", null: false
     t.bigint "teaching_period_id"
     t.index ["teaching_period_id"], name: "index_breaks_on_teaching_period_id"
   end
 
-  create_table "campuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "campuses", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "mode", null: false
     t.string "abbreviation", null: false
@@ -44,7 +44,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["name"], name: "index_campuses_on_name", unique: true
   end
 
-  create_table "comments_read_receipts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "comments_read_receipts", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "task_comment_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -54,7 +54,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["user_id"], name: "index_comments_read_receipts_on_user_id"
   end
 
-  create_table "discussion_comments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "discussion_comments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "time_started"
     t.datetime "time_completed"
     t.integer "number_of_prompts"
@@ -62,7 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "group_memberships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "group_memberships", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "group_id"
     t.bigint "project_id"
     t.boolean "active", default: true
@@ -72,7 +72,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["project_id"], name: "index_group_memberships_on_project_id"
   end
 
-  create_table "group_sets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "group_sets", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "unit_id"
     t.string "name"
     t.boolean "allow_students_to_create_groups", default: true
@@ -85,7 +85,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["unit_id"], name: "index_group_sets_on_unit_id"
   end
 
-  create_table "group_submissions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "group_submissions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "group_id"
     t.string "notes"
     t.bigint "submitted_by_project_id"
@@ -97,7 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["task_definition_id"], name: "index_group_submissions_on_task_definition_id"
   end
 
-  create_table "groups", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "groups", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "group_set_id"
     t.bigint "tutorial_id"
     t.string "name"
@@ -109,7 +109,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["tutorial_id"], name: "index_groups_on_tutorial_id"
   end
 
-  create_table "learning_outcome_task_links", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "learning_outcome_task_links", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "description"
     t.integer "rating"
     t.bigint "task_definition_id"
@@ -122,7 +122,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["task_id"], name: "index_learning_outcome_task_links_on_task_id"
   end
 
-  create_table "learning_outcomes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "learning_outcomes", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "unit_id"
     t.integer "ilo_number"
     t.string "name"
@@ -131,7 +131,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["unit_id"], name: "index_learning_outcomes_on_unit_id"
   end
 
-  create_table "logins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "logins", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "timestamp"
     t.bigint "user_id"
     t.datetime "created_at", null: false
@@ -139,7 +139,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["user_id"], name: "index_logins_on_user_id"
   end
 
-  create_table "overseer_assessments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "overseer_assessments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "task_id", null: false
     t.string "submission_timestamp", null: false
     t.string "result_task_status"
@@ -150,7 +150,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["task_id"], name: "index_overseer_assessments_on_task_id"
   end
 
-  create_table "overseer_images", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "overseer_images", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "tag", null: false
     t.datetime "created_at", null: false
@@ -160,7 +160,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.datetime "last_pulled_date"
   end
 
-  create_table "plagiarism_match_links", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plagiarism_match_links", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "task_id"
     t.bigint "other_task_id"
     t.integer "pct"
@@ -172,7 +172,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["task_id"], name: "index_plagiarism_match_links_on_task_id"
   end
 
-  create_table "projects", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "projects", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "unit_id"
     t.string "project_role"
     t.datetime "created_at", null: false
@@ -200,14 +200,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 
-  create_table "roles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "roles", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "task_comments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "task_comments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "task_id", null: false
     t.bigint "user_id", null: false
     t.string "comment", limit: 4096
@@ -238,7 +238,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["user_id"], name: "index_task_comments_on_user_id"
   end
 
-  create_table "task_definitions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "task_definitions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "unit_id"
     t.string "name"
     t.string "description", limit: 4096
@@ -268,7 +268,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["unit_id"], name: "index_task_definitions_on_unit_id"
   end
 
-  create_table "task_engagements", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "task_engagements", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "engagement_time"
     t.string "engagement"
     t.bigint "task_id"
@@ -277,7 +277,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["task_id"], name: "index_task_engagements_on_task_id"
   end
 
-  create_table "task_pins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "task_pins", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "task_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -287,14 +287,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["user_id"], name: "fk_rails_915df186ed"
   end
 
-  create_table "task_statuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "task_statuses", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "task_submissions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "task_submissions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "submission_time"
     t.datetime "assessment_time"
     t.string "outcome"
@@ -306,7 +306,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["task_id"], name: "index_task_submissions_on_task_id"
   end
 
-  create_table "tasks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "tasks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "task_definition_id"
     t.bigint "project_id"
     t.bigint "task_status_id"
@@ -333,7 +333,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["task_status_id"], name: "index_tasks_on_task_status_id"
   end
 
-  create_table "teaching_periods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "teaching_periods", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "period", null: false
     t.datetime "start_date", null: false
     t.datetime "end_date", null: false
@@ -342,7 +342,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["period", "year"], name: "index_teaching_periods_on_period_and_year", unique: true
   end
 
-  create_table "tutorial_enrolments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "tutorial_enrolments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "project_id", null: false
@@ -352,7 +352,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["tutorial_id"], name: "index_tutorial_enrolments_on_tutorial_id"
   end
 
-  create_table "tutorial_streams", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "tutorial_streams", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation", null: false
     t.datetime "created_at", null: false
@@ -366,7 +366,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["unit_id"], name: "index_tutorial_streams_on_unit_id"
   end
 
-  create_table "tutorials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "tutorials", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "unit_id"
     t.string "meeting_day"
     t.string "meeting_time"
@@ -385,7 +385,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["unit_role_id"], name: "index_tutorials_on_unit_role_id"
   end
 
-  create_table "unit_roles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "unit_roles", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "tutorial_id"
     t.datetime "created_at", null: false
@@ -398,7 +398,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["user_id"], name: "index_unit_roles_on_user_id"
   end
 
-  create_table "units", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "units", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "description", limit: 4096
     t.datetime "start_date"
@@ -427,7 +427,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["teaching_period_id"], name: "index_units_on_teaching_period_id"
   end
 
-  create_table "users", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "users", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -457,7 +457,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["role_id"], name: "index_users_on_role_id"
   end
 
-  create_table "webcal_unit_exclusions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "webcal_unit_exclusions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "webcal_id", null: false
     t.bigint "unit_id", null: false
     t.index ["unit_id", "webcal_id"], name: "index_webcal_unit_exclusions_on_unit_id_and_webcal_id", unique: true
@@ -465,7 +465,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_064217) do
     t.index ["webcal_id"], name: "fk_rails_d5fab02cb7"
   end
 
-  create_table "webcals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "webcals", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "guid", limit: 36, null: false
     t.boolean "include_start_dates", default: false, null: false
     t.bigint "user_id"


### PR DESCRIPTION
# Description

This changes creates a new migrations and adjust the DB schema to change the task comment word fail to show "Needs Improvement" this is to match the front end change doing the same thing for tasks.

Fixes # fix task fail name

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested in local environment as students, Tutor and Unit head.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings

If you have any questions, please contact @macite or @jakerenzella.
