### PR TITLE
fix: inline latex math display in pdfs generated from ipynb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,5 @@ gem 'icalendar'
 gem 'rest-client'
 
 gem 'net-smtp', require: false
+
+gem 'pdf-reader'

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test, :staging do
   gem 'minitest'
   gem 'minitest-around'
   gem 'webmock'
+  gem 'pdf-reader'
 end
 
 # Database
@@ -89,5 +90,3 @@ gem 'icalendar'
 gem 'rest-client'
 
 gem 'net-smtp', require: false
-
-gem 'pdf-reader'

--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,8 @@ group :development, :test, :staging do
   gem 'faker'
   gem 'minitest'
   gem 'minitest-around'
-  gem 'webmock'
   gem 'pdf-reader'
+  gem 'webmock'
 end
 
 # Database

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.1.0)
     actioncable (7.0.4.3)
       actionpack (= 7.0.4.3)
       activesupport (= 7.0.4.3)
@@ -69,6 +70,7 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
+    afm (0.2.2)
     amq-protocol (2.3.2)
     ast (2.4.2)
     backport (1.2.0)
@@ -170,6 +172,7 @@ GEM
     grape-swagger-rails (0.3.1)
       railties (>= 3.2.12)
     hashdiff (1.0.1)
+    hashery (2.1.2)
     hirb (0.7.3)
     http-accept (1.7.0)
     http-cookie (1.0.5)
@@ -242,6 +245,12 @@ GEM
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
+    pdf-reader (2.11.0)
+      Ascii85 (~> 1.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pkg-config (1.5.1)
     public_suffix (5.0.1)
     puma (6.1.1)
@@ -340,6 +349,7 @@ GEM
     ruby-filemagic (0.7.3)
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.13.0)
+    ruby-rc4 (0.1.5)
     ruby-saml (1.13.0)
       nokogiri (>= 1.10.5)
       rexml
@@ -384,6 +394,7 @@ GEM
     thor (1.2.1)
     tilt (2.1.0)
     timeout (0.3.2)
+    ttfunk (1.7.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -436,6 +447,7 @@ DEPENDENCIES
   moss_ruby (>= 1.1.4)
   mysql2
   net-smtp
+  pdf-reader
   puma
   rack-cors
   rails (~> 7.0)

--- a/app/views/layouts/application.pdf.erbtex
+++ b/app/views/layouts/application.pdf.erbtex
@@ -13,7 +13,7 @@
     \input|"python3 jupynotex.py #2 #1"
 }
 
-\usepackage[fencedCode,hashEnumerators]{markdown}
+\usepackage[fencedCode,hashEnumerators,pipeTables,texMathDollars]{markdown}
 
 \usepackage{luatextra}
 \defaultfontfeatures{Ligatures=TeX}

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -357,9 +357,19 @@ class TaskDefinitionTest < ActiveSupport::TestCase
     assert File.exist? path
     assert File.exist? task.final_pdf_path
 
+    # Check inline latex math display
+    pdf_content = read_pdf_content(task.final_pdf_path)
+    assert_includes pdf_content, "bmi =     weigh2\n                                           height"
+
     td.destroy
     assert_not File.exist? path
     unit.destroy!
+  end
+
+  def read_pdf_content(pdf_path)
+    require 'pdf-reader'
+    pdf_reader = PDF::Reader.new(pdf_path)
+    pdf_reader.pages.map(&:text).join("\n")
   end
 
 end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'pdf-reader'
 
 #
 # Contains tests for Task model objects - not accessed via API
@@ -357,19 +358,11 @@ class TaskDefinitionTest < ActiveSupport::TestCase
     assert File.exist? path
     assert File.exist? task.final_pdf_path
 
-    # Check inline latex math display
-    pdf_content = read_pdf_content(task.final_pdf_path)
-    assert_includes pdf_content, "bmi =     weigh2\n                                           height"
+    reader = PDF::Reader.new(task.final_pdf_path)
+    assert reader.pages[3].text.include? "bmi =     weigh2\n                                           height"
 
     td.destroy
     assert_not File.exist? path
     unit.destroy!
   end
-
-  def read_pdf_content(pdf_path)
-    require 'pdf-reader'
-    pdf_reader = PDF::Reader.new(pdf_path)
-    pdf_reader.pages.map(&:text).join("\n")
-  end
-
 end

--- a/test_files/submissions/vectorial_graph.ipynb
+++ b/test_files/submissions/vectorial_graph.ipynb
@@ -937,6 +937,20 @@
    "source": [
     "Testing a raw cell with $10 invalid latex code"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Testing inline latex math display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Formula for calculating BMI: $\\text{bmi}=\\frac{\\text{weight}}{\\text{height}^2}$"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
# Description

Fixed the issue where inline latex math was not rendering as correct math notation in PDFs converted from Jupyter Notebook (.ipynb) files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Extended the `test_ipynb_to_pdf` test to check if the sample inline math is displayed correctly after generating the PDF. Run the following inside the test environment to run the test:

`bundle exec rails test test/models/task_test.rb:320`

## Before

![before](https://github.com/doubtfire-lms/doubtfire-api/assets/117552851/f254ecf9-7fc9-4505-a385-695ab97787f4)

The image below shows what the PDF content looks like in plain text when the inline math is not rendered correctly. It also shows how the test fails because of this.

![before-terminal](https://github.com/doubtfire-lms/doubtfire-api/assets/117552851/3a5df09f-5e05-422a-89fe-294515f6fb50)

## After

![after](https://github.com/doubtfire-lms/doubtfire-api/assets/117552851/855f0e83-b8ea-4498-ae7c-373623db5e27)

The image below shows the test running successfully due to the inline math being rendered correctly.

![after-terminal](https://github.com/doubtfire-lms/doubtfire-api/assets/117552851/834c6a04-93ab-4cf8-ba2a-78fcc7af73d7)

#### Note:

This is how the PDF content in plain text looks like when the sample inline math is rendered correctly:

![note](https://github.com/doubtfire-lms/doubtfire-api/assets/117552851/98281f96-b4b0-4a46-a322-eb4760d2e7c8)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules