### PR TITLE
fix: inline latex math display in pdfs generated from ipynb

### DIFF
--- a/app/views/layouts/application.pdf.erbtex
+++ b/app/views/layouts/application.pdf.erbtex
@@ -13,7 +13,7 @@
     \input|"python3 jupynotex.py #2 #1"
 }
 
-\usepackage[fencedCode,hashEnumerators]{markdown}
+\usepackage[fencedCode,hashEnumerators,pipeTables,texMathDollars]{markdown}
 
 \usepackage{luatextra}
 \defaultfontfeatures{Ligatures=TeX}

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'pdf-reader'
 
 #
 # Contains tests for Task model objects - not accessed via API
@@ -356,6 +357,10 @@ class TaskDefinitionTest < ActiveSupport::TestCase
     assert path
     assert File.exist? path
     assert File.exist? task.final_pdf_path
+
+    # Test if latex math was rendered properly
+    reader = PDF::Reader.new(task.final_pdf_path)
+    assert reader.pages[3].text.include? "bmi =     weigh2\n                                           height"
 
     td.destroy
     assert_not File.exist? path

--- a/test_files/submissions/vectorial_graph.ipynb
+++ b/test_files/submissions/vectorial_graph.ipynb
@@ -937,6 +937,20 @@
    "source": [
     "Testing a raw cell with $10 invalid latex code"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Testing inline latex math display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Formula for calculating BMI: $\\text{bmi}=\\frac{\\text{weight}}{\\text{height}^2}$"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
# Description

Fixed the issue where inline latex math was not rendering as correct math notation in PDFs converted from Jupyter Notebook (.ipynb) files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Extended the `test_ipynb_to_pdf` test to check if the sample inline math is displayed correctly after generating the PDF. Run the following inside the test environment to run the test:

`bundle exec rails test test/models/task_test.rb:320`

## Before

![before](https://github.com/doubtfire-lms/doubtfire-api/assets/117552851/f254ecf9-7fc9-4505-a385-695ab97787f4)

The image below shows what the PDF content looks like in plain text when the inline math is not rendered correctly. It also shows how the test fails because of this.

![before-terminal](https://github.com/doubtfire-lms/doubtfire-api/assets/117552851/3a5df09f-5e05-422a-89fe-294515f6fb50)

## After

![after](https://github.com/doubtfire-lms/doubtfire-api/assets/117552851/855f0e83-b8ea-4498-ae7c-373623db5e27)

The image below shows the test running successfully due to the inline math being rendered correctly.

![after-terminal](https://github.com/doubtfire-lms/doubtfire-api/assets/117552851/834c6a04-93ab-4cf8-ba2a-78fcc7af73d7)

#### Note:

This is how the PDF content in plain text looks like when the sample inline math is rendered correctly:

![note](https://github.com/doubtfire-lms/doubtfire-api/assets/117552851/98281f96-b4b0-4a46-a322-eb4760d2e7c8)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules