### PR TITLE
Fix: Jupyter notebook LaTeX math tests

### DIFF
--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -360,7 +360,12 @@ class TaskDefinitionTest < ActiveSupport::TestCase
 
     # Test if latex math was rendered properly
     reader = PDF::Reader.new(task.final_pdf_path)
-    assert reader.pages.last.text.include?("weight\n")
+
+    # PDF-reader incorrectly parses "weight (kg) / height (m)^2" as "weight (2g) / height (m)", misplacing the ^2
+    # Detecting "height" and "weight" confirms correct LaTeX rendering
+    assert reader.pages.last.text.include?("BMI: bmi =")
+    assert reader.pages.last.text.include?("weight")
+    assert reader.pages.last.text.include?("height (m)\n")
 
     # ensure the notice is not included when the notebook doesn't have long lines source code cells
     # and no errors

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -365,7 +365,7 @@ class TaskDefinitionTest < ActiveSupport::TestCase
     # Detecting "height" and "weight" confirms correct LaTeX rendering
     assert reader.pages.last.text.include?("BMI: bmi =")
     assert reader.pages.last.text.include?("weight")
-    assert reader.pages.last.text.include?("height (m)\n")
+    assert reader.pages.last.text.include?("height (m)")
 
     # ensure the notice is not included when the notebook doesn't have long lines source code cells
     # and no errors

--- a/test_files/submissions/vectorial_graph.ipynb
+++ b/test_files/submissions/vectorial_graph.ipynb
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -951,7 +951,7 @@
    "source": [
     "Formula for calculating\n",
     "\n",
-    "BMI: $\\text{bmi}=\\frac{\\text{weight}}{\\text{height}^2}$"
+    "BMI: $\\text{bmi}=\\frac{\\text{weig}\\text{ht (kg)}}{\\text{hei} \\text{ght (m)}^2}$"
    ]
   }
  ],


### PR DESCRIPTION
# Description

This fixes and improves the tests used in `test_ipynb_to_pdf` to confirm valid PDF rendering of LaTeX math in jupyter notebooks. The `pdf-reader` incorrectly parses a valid render of the inline math as `BMI: bmi = weigh2` instead of `weight`.

I extended the LaTeX to ensure full words like `weight` and `height` are parsed correctly, though `(kg)` is still incorrectly parsed as `(2g)` (see below). Now, tests confirm a valid PDF render by checking for `weight` and `height` without needing to check for newlines or other notation.

I also used `text{hei}text{ght}` to separate the words to guarantee a reliable unit test pass if the words are detected. Below is a before/after of the inline LaTeX, the PDF render, and the output of `pdf-reader`.	


## Before
#### Inline math LaTeX:
```tex
$\text{bmi}=\frac{\text{weight}}{\text{height}^2}$
```
#### PDF Render
![before-inline-math](https://github.com/user-attachments/assets/b7fc746e-7ba7-4ea0-b3d0-710d4f0ba92c)

#### `pdf-reader` output 
```plaintext
BMI: bmi =		weigh2
				height
```
## After
#### Inline math LaTeX:
```tex
$\text{bmi}=\frac{\text{weig}\text{ht (kg)}}{\text{hei} \text{ght (m)}^2}$
```
#### PDF Render
![after-inline-math](https://github.com/user-attachments/assets/3c8deadd-ce8f-4145-bf75-46bf1de7a849)

#### `pdf-reader` output 
```plaintext
BMI: bmi =		weight (2g)
				height (m)
```

### Tests used to confirm math latex rendered correctly
```ruby
assert reader.pages.last.text.include?("BMI: bmi =")
assert reader.pages.last.text.include?("weight")
assert reader.pages.last.text.include?("height (m)")
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`rake test`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes