### PR TITLE
Fix: no auth method mailer

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Doubtfire::Application.configure do
       domain: ENV.fetch('DF_SMTP_DOMAIN', nil),
       user_name: ENV.fetch('DF_SMTP_USERNAME', nil),
       password: ENV.fetch('DF_SMTP_PASSWORD', nil),
-      authentication: ENV.fetch('DF_SMTP_AUTHENTICATION', 'plain'),
+      authentication: ENV.fetch('DF_SMTP_AUTHENTICATION', nil),
       enable_starttls_auto: true
     }
   end


### PR DESCRIPTION
## WARNING: This change may require servers to set `DF_SMTP_AUTHENTICATION` to `plain` as that was the previous default.

Currently, mailer auth defaults to `plain`.

Some mailers don't rely on mailer auth, and instead use internal IP ranges.

No-auth method smtp relies on the lack of an auth key, and there is no valid value to default to.

The defaul plain method meant that non-auth mailers can't set the auth method correctly.

## WARNING: This may require servers to set `DF_SMTP_AUTHENTICATION` to `plain` as that was the previous default.