### PR TITLE
CORS web security patch fix on doubtfire-api

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -177,12 +177,21 @@ module Doubtfire
       Rails.root.join('app', 'models', 'similarity')
 
     # CORS config
-    config.middleware.insert_before Warden::Manager, Rack::Cors do
+    # config.middleware.insert_before Warden::Manager, Rack::Cors do
+    #  allow do
+    #    origins '*'
+    #    resource '*', headers: :any, methods: %i(get post put delete options)
+    #  end
+    # end
+
+    # Updated CORS Security Patch Fix
+     config.middleware.insert_before Warden::Manager, Rack::Cors do
       allow do
-        origins '*'
+        origins ENV['DF_ALLOWED_ORIGINS'].split(',')
         resource '*', headers: :any, methods: %i(get post put delete options)
       end
-    end
+     end
+
     # Generators for test framework
     if Rails.env.test?
       config.generators do |g|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,12 @@ services:
     environment:
       RAILS_ENV: 'development'
 
+      # CORS Vulnerability Remediation
+      # The DF_ALLOWED_ORIGINS variable must reflect the exact URLs where the OnTrack app will be accessed (e.g., production, staging, or development URLs).
+      # Allowed origins must reflect the exact URLs where the OnTrack app will be accessed.
+      # Failure to update this variable with the correct origins will cause inaccessibility.
+      DF_ALLOWED_ORIGINS: "http://localhost:4200"
+
       DF_STUDENT_WORK_DIR: /student-work
       DF_INSTITUTION_HOST: http://localhost:3000
       DF_INSTITUTION_PRODUCT_NAME: OnTrack


### PR DESCRIPTION
**See https://github.com/thoth-tech/doubtfire-api/pull/47**

**Title**: "Security Patch Fix: Addressing CORS Vulnerability for OnTrack Application"

---

**Summary**:  

This PR addresses a Cross-Origin Resource Sharing (CORS) vulnerability in the OnTrack application caused by the use of the `Access-Control-Allow-Origin: *` header. The current configuration poses significant security risks by allowing unrestricted cross-origin access.

---

**Impacts**:  
- **Unauthorized Access**:  
  Any website can interact with the API, potentially leading to data leakage or abuse.  
- **Increased Attack Surface**:  
  Vulnerable to cross-origin attacks and other malicious activities.  
- **Compliance Risks**:  
  Violates security and privacy standards.

---

**Remediation**:  
- **Preferred Option**: Restrict `Access-Control-Allow-Origin`:  
  - Implement a restrictive CORS policy using the `DF_ALLOWED_ORIGINS` environment variable for flexibility.  
  - Update backend configurations in:  
    - **Docker**: `/doubtfire-api/docker-compose.yml`  
    - **Rails**: `/doubtfire-api/config/application.rb`  

**Configuration Updates**:  
1. **Docker**:  
   - Add the following environment variable:  
     ```yaml
     DF_ALLOWED_ORIGINS: "http://localhost:4200"
     ```
   - **Notes**:  
     - The `DF_ALLOWED_ORIGINS` variable must reflect the exact URLs where the OnTrack app will be accessed (e.g., production, staging, or development environments).  
     - Failure to update this variable correctly will result in inaccessibility for valid clients.  

2. **Rails**:  
   - Add middleware configuration in `application.rb`:  
     ```ruby
     config.middleware.insert_before Warden::Manager, Rack::Cors do
       allow do
         origins ENV['DF_ALLOWED_ORIGINS'].split(',')
         resource '*', headers: :any, methods: %i[get post put delete options]
       end
     end
     ```

---

**Files docker-compose.yml and config/application.rb have been updated**