### PR TITLE
Fix: handle allocate+ data user import

### DIFF
--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -763,7 +763,17 @@ class Unit < ApplicationRecord
         if changes.key? username
           if row_data[:enrolled] # they should be enrolled - record that... overriding anything else
             # record previous row as ignored
-            ignored << { row: changes[username][:row], message: "Skipping duplicate role - ensuring enrolled" }
+            ignored_entry = { row: changes[username][:row], message: 'Skipping duplicate role - ensuring enrolled.' }
+
+            # Allocate+ csv data may have duplicate student rows for each tutorial enrolment
+            # We need to combine the tutorials from both rows so that the student is enrolled into each tutorial
+            if import_settings[:merge_tutorials_for_duplicate_students] && changes[username][:tutorials]&.any?
+                row_data[:tutorials] ||= []
+                row_data[:tutorials].concat(changes[username][:tutorials])
+                ignored_entry[:message] += ' Merged tutorial enrolments.'
+            end
+
+            ignored << ignored_entry
             changes[username] = row_data
           else
             # record this row as skipped

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -631,9 +631,17 @@ class Unit < ApplicationRecord
     end
 
     # Check if these headers should be processed by institution file or from DF format
+    # Asking "Who will convert the users to the right format?"
+    # If these are "institution formatted"? then use import settings from institution settings
+    # Which contain:
+    #  - function to check if row is missing header values
+    #  - function to convert row to hash in the required format
+    #  - booleans for replacing tutorial/campus if different
     if Doubtfire::Application.config.institution_settings.are_headers_institution_users? csv.headers
+      logger.debug 'Importing users using institution\'s import settings'
       import_settings = Doubtfire::Application.config.institution_settings.user_import_settings_for(csv.headers)
     else
+      logger.debug 'Importing users using default import settings'
       if tutorial_streams.count > 0
         stream_names = tutorial_stream_abbr.map { |abbr| abbr.downcase }
       else


### PR DESCRIPTION
# Description

If student import csv data contains duplicate student rows for each tutorial enrolment, optional import setting can be used to  merge the tutorials into a single tutorial list (ensuring student is enrolled into all the tutorials)

will also require the `replace_existing_tutorial` import setting to be enabled