### PR TITLE
Fix/numbas username route

### DIFF
--- a/app/api/scorm_api.rb
+++ b/app/api/scorm_api.rb
@@ -52,7 +52,9 @@ class ScormApi < Grape::API
   params do
     requires :task_def_id, type: Integer, desc: 'Task Definition ID to get SCORM test data for'
   end
-  get '/scorm/:task_def_id/:username/:auth_token/*file_path' do
+
+  # NOTE: allow '.' in username; without this Rails/Grape treats '.' as format.
+  get '/scorm/:task_def_id/:username/:auth_token/*file_path', requirements: { username: /[^\/]+/ }  do
     task_def = TaskDefinition.find(params[:task_def_id])
 
     unless authorise? current_user, task_def.unit, :get_unit

--- a/app/api/scorm_api.rb
+++ b/app/api/scorm_api.rb
@@ -54,7 +54,7 @@ class ScormApi < Grape::API
   end
 
   # NOTE: allow '.' in username; without this Rails/Grape treats '.' as format.
-  get '/scorm/:task_def_id/:username/:auth_token/*file_path', requirements: { username: /[^\/]+/ }  do
+  get '/scorm/:task_def_id/:username/:auth_token/*file_path', requirements: { username: %r{[^/]+} } do
     task_def = TaskDefinition.find(params[:task_def_id])
 
     unless authorise? current_user, task_def.unit, :get_unit

--- a/test/api/scorm_api_test.rb
+++ b/test/api/scorm_api_test.rb
@@ -10,7 +10,10 @@ class ScormApiTest < ActiveSupport::TestCase
   end
 
   def scorm_path(task_def, user, file, token_type = :scorm)
-    "/api/scorm/#{task_def.id}/#{user.username.gsub('.', '%2e')}/#{auth_token(user, token_type)}/#{file}"
+    # NOTE: Do not encode '.' to '%2e' here. That hid the bug because the request worked regardless
+    # of the route constraint. Keeping the raw username ensures tests fail without the fix and pass
+    # with it.
+    "/api/scorm/#{task_def.id}/#{user.username}/#{auth_token(user, token_type)}/#{file}"
   end
 
   def test_serve_scorm_content
@@ -85,5 +88,23 @@ class ScormApiTest < ActiveSupport::TestCase
     tutor.destroy!
     td.destroy!
     unit.destroy!
+  end
+
+  def test_username_with_dot_fails_without_fix
+    unit = FactoryBot.create(:unit)
+    user = unit.projects.first.student
+    user.update!(username: "user.name")
+
+    td = FactoryBot.create(:task_definition,
+      unit: unit,
+      tutorial_stream: unit.tutorial_streams.first,
+      scorm_enabled: true
+    )
+    td.add_scorm_data(test_file_path("numbas.zip"), copy: true)
+    td.save!
+
+    # This should fail without the route fix (Rails interprets '.' as format separator)
+    get scorm_path(td, user, "index.html")
+    assert_equal 200, last_response.status
   end
 end


### PR DESCRIPTION
# Description

Rails/Grape interprets `.` in a path segment as a format separator, which broke lookups for
usernames containing dots (e.g. `"user.name"`). Added a route requirement so `:username` matches
any non-slash characters. Also updated tests so they correctly fail without this fix.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually reviewed a Numbas test attempt from an account with `.` in the username from a Chromium-based browser, Sarari and Firefox  
  - Previously: `404 Not Found` error (Rails parsed `.` as a format)  
  - Currently: request completes successfully even when `.` is present  
  - Tested in: Safari, Firefox, Brave (Chromium based)

- [x] Unit tests:
  - Updated `scorm_path` helper to stop encoding `.` as `%2e`, so the bug is exposed.
  - Added `test_username_with_dot_fails_without_fix` to assert that lookups for usernames
    containing dots succeed.  
    - This test fails without the route fix (404) and passes with the fix (200).
  - All other unit tests continue to pass.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
