### PR TITLE
fix: ensure long comments are appended on a new page #303

### DIFF
--- a/app/views/layouts/application.pdf.erbtex
+++ b/app/views/layouts/application.pdf.erbtex
@@ -42,6 +42,7 @@
 \usepackage{lastpage}
 \usepackage{multirow}
 \usepackage[colorlinks]{hyperref}
+\usepackage{longtable}
 \hypersetup{colorlinks,
   linkcolor=black,
   filecolor=black,

--- a/app/views/portfolio/portfolio_pdf.pdf.erb
+++ b/app/views/portfolio/portfolio_pdf.pdf.erb
@@ -257,7 +257,7 @@ end # if there are linked outcomes
   end # if outcomes exist
   if task.comments.count > 0
 %>
-    \begin{tabular}{p{3cm}|p{3cm}|p{9cm}}
+    \begin{longtable}{p{3cm}|p{3cm}|p{9cm}}
       \textbf{Date} & \textbf{Author} & \textbf{Comment} \\ \hline
 <%
     task.comments.each do |comment|
@@ -266,7 +266,7 @@ end # if there are linked outcomes
 <%
     end # comments loop
 %>
-    \end{tabular}
+    \end{longtable}
 <%
   end # if comments exist
 

--- a/app/views/portfolio/portfolio_pdf.pdf.erb
+++ b/app/views/portfolio/portfolio_pdf.pdf.erb
@@ -261,8 +261,12 @@ end # if there are linked outcomes
       \textbf{Date} & \textbf{Author} & \textbf{Comment} \\ \hline
 <%
     task.comments.each do |comment|
+      full_text = comment.comment
+      chunks = full_text.scan(/.{1,2000}/m) # split into 2000-char chunks
 %>
-        <%= lesc comment.created_at.localtime.strftime("%Y/%m/%d %H:%M") %> & <%= lesc comment.user.name %> & <%= lesc comment.comment %> \\
+    <% chunks.each_with_index do |chunk, i| %>
+      <%= lesc comment.created_at.localtime.strftime("%Y/%m/%d %H:%M") %> & <%= lesc comment.user.name %> & <%if i > 0 %>\textit{\textcolor{gray}{[continued...]}}<% end %> <%= lesc chunk %> <% if i < chunks.size - 1 %> \textit{\textcolor{gray}{[comment has been split due to length]}}<% end %> \\
+    <% end %>
 <%
     end # comments loop
 %>


### PR DESCRIPTION
Fixes #303

This only fixes multiple comments separated onto multiple pages.

~~Long comments that take up a full page may need to be split first, or truncated entirely~~

Comments longer than 2000 characters are now split up into multiple comments, allowing each chunk to be rendered on additional pages. Comments with 2000 characters should roughly take up 80-90% of the PDF page - other ASCII characters or languages may exceed the page length