### PR TITLE
docs: fix typo in API root, add doc_version

### DIFF
--- a/app/api/api_root.rb
+++ b/app/api/api_root.rb
@@ -153,10 +153,10 @@ class ApiRoot < Grape::API
 
   add_swagger_documentation \
     base_path: nil,
-    api_version: 'v1',
+    doc_version: 'v10.0.0',
     hide_documentation_path: true,
     info: {
-      title: 'Doubtfire API Documentaion',
+      title: 'Doubtfire API Documentation',
       description: 'Doubtfire is a modern, lightweight learning management system.',
       license: 'AGPL v3.0',
       license_url: 'https://github.com/doubtfire-lms/doubtfire-api/blob/master/LICENSE'


### PR DESCRIPTION
# Description

The Swagger document still said "documentaion". Nuts. I have also added the doc version number. For this, I defaulted to the version of the branch.

Fixes a typo.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Test A

- Start the `doubtfire_api` module
- Navigate to `localhost:3000/api/docs`
- Notice that _"Documentaion"_ has been changed to _"Documentation"_
- Notice the footer of the Swagger doc now correctly reflects the API version as `10.0.x`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~I have created or extended unit tests to address my new additions~~
- [x] New and existing unit tests pass locally with my changes
- [x] ~~Any dependent changes have been merged and published in downstream modules~~

If you have any questions, please contact @macite or @jakerenzella.
