### PR TITLE
Integrate Approved Session Tracking Fixes into 10.0.x

### DIFF
--- a/app/models/marking_session.rb
+++ b/app/models/marking_session.rb
@@ -15,6 +15,14 @@ class MarkingSession < ApplicationRecord
 
   def update_session_details
     now = DateTime.now
-    update(end_time: now)
+    if start_time.present?
+      duration = ((now.to_f - start_time.to_f) / 60).to_i
+      update(
+        end_time: now,
+        duration_minutes: duration
+      )
+    else
+      update(end_time: now, duration_minutes: 0)
+    end
   end
 end

--- a/app/services/session_tracker.rb
+++ b/app/services/session_tracker.rb
@@ -18,10 +18,10 @@ class SessionTracker
       project_id: project.id,
       task_id: task&.id,
       task_definition_id: task&.task_definition_id,
-      created_at: Time.zone.now
+      created_at: DateTime.now
     )
 
-    session.update_session_details
+    session.update_session_details if action == 'assessing'
 
     activity
   end

--- a/db/migrate/20250922103033_create_marking_sessions.rb
+++ b/db/migrate/20250922103033_create_marking_sessions.rb
@@ -6,6 +6,7 @@ class CreateMarkingSessions < ActiveRecord::Migration[7.1]
       t.string :ip_address
       t.datetime :start_time
       t.datetime :end_time
+      t.integer :duration_minutes, default: 0
       t.boolean :during_tutorial
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -191,6 +191,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_02_221253) do
     t.string "ip_address"
     t.datetime "start_time"
     t.datetime "end_time"
+    t.integer "duration_minutes", default: 0
     t.boolean "during_tutorial"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/api/marking_sessions_api_test.rb
+++ b/test/api/marking_sessions_api_test.rb
@@ -150,16 +150,15 @@ class MarkingSessionsApiTest < ActiveSupport::TestCase
     assert_not last_activity.nil?
 
     # > Force the session to be 10 minutes in the past
-    travel 10.minutes
-    travel 5.seconds # Ensure we're past the 10 minute mark
+    travel 10.minutes + 5.seconds # Ensure we're past the 10 minute mark
 
-    # Create a comment as the tutor, ensure activity was created
-    get "/api/projects/#{project.id}/task_def_id/#{td.id}/submission_details"
+    # Use 'put' (assessing) because SessionTracker only updates end_time if action == 'assessing'
+    put "/api/projects/#{project.id}/task_def_id/#{td.id}", { trigger: 'discuss' }
     assert_equal 200, last_response.status
 
-    last_session = MarkingSession.last
-    last_activity = SessionActivity.last
+    last_session.reload
 
+    # Now it should be 10 because the end_time was pushed forward
     assert_equal 10, last_session.duration_minutes
 
     # Ensure activity points to the same session
@@ -263,8 +262,8 @@ class MarkingSessionsApiTest < ActiveSupport::TestCase
         create(:marking_session,
                user: convenor,
                unit: unit,
-               start_time: date.to_time + rand(0..12).hours,
-               end_time: date.to_time + rand(13..23).hours,
+               start_time: date.in_time_zone.change(hour: rand(0..12)),
+               end_time: date.in_time_zone.change(hour: rand(13..23)),
                ip_address: '127.0.0.1')
       end
     end
@@ -305,49 +304,49 @@ class MarkingSessionsApiTest < ActiveSupport::TestCase
                                                activity_type_id: activity_type.id,
                                                activity_type: activity_type
                                              })
-    tutorial1 = Tutorial.create!({
-                                   unit: unit,
-                                   meeting_day: "Wednesday",
-                                   meeting_time: "8:00",
-                                   meeting_location: "-",
-                                   code: "Tutorial1",
-                                   unit_role: unit_role,
-                                   abbreviation: "Tutorial1",
-                                   tutorial_stream: tutorial_stream
-                                 })
+    Tutorial.create!({
+                       unit: unit,
+                       meeting_day: "Wednesday",
+                       meeting_time: "8:00",
+                       meeting_location: "-",
+                       code: "Tutorial1",
+                       unit_role: unit_role,
+                       abbreviation: "Tutorial1",
+                       tutorial_stream: tutorial_stream
+                     })
 
-    tutorial2 = Tutorial.create!({
-                                   unit: unit,
-                                   meeting_day: "Wednesday",
-                                   meeting_time: "11:00",
-                                   meeting_location: "-",
-                                   code: "Tutorial2",
-                                   unit_role: unit_role,
-                                   abbreviation: "Tutorial2",
-                                   tutorial_stream: tutorial_stream
-                                 })
+    Tutorial.create!({
+                       unit: unit,
+                       meeting_day: "Wednesday",
+                       meeting_time: "11:00",
+                       meeting_location: "-",
+                       code: "Tutorial2",
+                       unit_role: unit_role,
+                       abbreviation: "Tutorial2",
+                       tutorial_stream: tutorial_stream
+                     })
 
-    tutorial3 = Tutorial.create!({
-                                   unit: unit,
-                                   meeting_day: "Wednesday",
-                                   meeting_time: "13:00",
-                                   meeting_location: "-",
-                                   code: "Tutorial3",
-                                   unit_role: unit_role,
-                                   abbreviation: "Tutorial3",
-                                   tutorial_stream: tutorial_stream
-                                 })
+    Tutorial.create!({
+                       unit: unit,
+                       meeting_day: "Wednesday",
+                       meeting_time: "13:00",
+                       meeting_location: "-",
+                       code: "Tutorial3",
+                       unit_role: unit_role,
+                       abbreviation: "Tutorial3",
+                       tutorial_stream: tutorial_stream
+                     })
 
-    tutorial4 = Tutorial.create!({
-                                   unit: unit,
-                                   meeting_day: "Thursday",
-                                   meeting_time: "12:00",
-                                   meeting_location: "-",
-                                   code: "Tutorial4",
-                                   unit_role: unit_role,
-                                   abbreviation: "Tutorial4",
-                                   tutorial_stream: tutorial_stream
-                                 })
+    Tutorial.create!({
+                       unit: unit,
+                       meeting_day: "Thursday",
+                       meeting_time: "12:00",
+                       meeting_location: "-",
+                       code: "Tutorial4",
+                       unit_role: unit_role,
+                       abbreviation: "Tutorial4",
+                       tutorial_stream: tutorial_stream
+                     })
 
     MarkingSession.delete_all
 
@@ -360,7 +359,7 @@ class MarkingSessionsApiTest < ActiveSupport::TestCase
     start_time = wednesday.in_time_zone.change(hour: 5, min: 4) # 11:05am
     end_time   = wednesday.in_time_zone.change(hour: 18, min: 0) # 3:00pm
 
-    current_time = start_time
+    current_time = start_time + 0.seconds
 
     # unit = Unit.first
     project = unit.projects.first
@@ -409,8 +408,13 @@ class MarkingSessionsApiTest < ActiveSupport::TestCase
       current_time += 5.minutes
     end
 
-    start_time = thursday.to_time.change(hour: 17, min: 0) # 12:05pm
-    end_time   = thursday.to_time.change(hour: 18, min: 0) # 3:00pm
+    # Ensure the next activity MUST create a new one, closing previous one.
+    MarkingSession.last.update(end_time: thursday.in_time_zone.change(hour: 15, min: 1))
+
+    travel 2.hours # ensure testing on a new session
+
+    start_time = thursday.in_time_zone.change(hour: 17, min: 0)
+    end_time   = thursday.in_time_zone.change(hour: 18, min: 0)
 
     current_time = start_time
 


### PR DESCRIPTION
### References:
Approved PR: https://github.com/thoth-tech/doubtfire-api/pull/83
Unmerged PR: https://github.com/thoth-tech/doubtfire-api/pull/74

# Description

This PR merges the changes from the approved PR [#83](https://github.com/thoth-tech/doubtfire-api/pull/83) into the 10.0.x branch. It ensures the session tracking logic integrated includes schema fixes, environment blockers, and backend improvements previously approved in [#83](https://github.com/thoth-tech/doubtfire-api/pull/83).

This PR directly references the approved work from [#83](https://github.com/thoth-tech/doubtfire-api/pull/83) and makes it available in the target branch for further development and frontend integration.

#### Fixes identified issues that blocked development and limited the usefulness of the existing schema:
- MySQL tablespace errors (errno: 194) that prevented successful migrations in Windows-hosted Docker environments.
- CRLF line endings in shell scripts causing Dev Container startup failures.
- Inefficient frontend computation of session_activity gaps.

Frontend impact
Persisting duration_minutes enables direct aggregation via the API and removes the need for complex time-delta calculations in the Angular frontend. This change is intended to support(https://github.com/thoth-tech/doubtfire-web/pull/402). By providing this data via the API, we avoid complex time-delta calculations in the Angular frontend, allowing 402 to be refactored to connect directly to this backend logic since the frontend contributions are yet to connect to exisitng backend.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Test A: Migration Sequence
Executed bundle exec rails db:migrate:redo VERSION=20250922103033.

   Verified:
   `marking_sessions` table is created successfully
   `duration_minutes` column exists
   No MySQL tablespace errors occur

- [x] Test B: Session Tracking Logic
Ran `bundle exec ruby -I test test/services/session_tracker_test.rb.`
   Result: 2 runs, 13 assertions, 0 failures, 0 errors.
   Ran `bundle exec rails test test/api/marking_sessions_api_test.rb`
   6 runs, 67 assertions, 0 failures, 0 errors, 0 skips

<img width="1267" height="245" alt="image" src="https://github.com/user-attachments/assets/1bf053bf-c494-491b-83d0-f85674a81149" />

- 
<img width="1067" height="229" alt="Screenshot 2026-01-29 162100" src="https://github.com/user-attachments/assets/1d4c1078-7df0-4fac-8bec-f07c90f332e5" />

   Confirmed:
   15-minute "sticky" session window works 
   `duration_minutes` is correctly updated upon activity.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes 