### PR TITLE
feat(peer-progress): Peer anonymized data fetch

### DIFF
--- a/app/api/projects_api.rb
+++ b/app/api/projects_api.rb
@@ -34,6 +34,46 @@ class ProjectsApi < Grape::API
     end
   end
 
+  desc 'Get anonymized peer progress for a project unit'
+  params do
+    requires :id, type: Integer, desc: 'The id of the project to get peer progress for'
+  end
+  get '/projects/:id/peer_progress' do
+    project = Project.eager_load(:unit, :user).find(params[:id])
+
+    unless authorise? current_user, project, :get
+      error!({ error: "Couldn't find Project with id=#{params[:id]}" }, 403)
+    end
+
+    peers = project.unit.active_projects.includes(:user).order('projects.id ASC').map.with_index(1) do |peer_project, index|
+      task_stats = begin
+        peer_project.task_stats.present? ? JSON.parse(peer_project.task_stats) : {}
+      rescue StandardError
+        {}
+      end
+      progress = task_stats['order_scale'].to_f.round
+      progress = 0 if progress.negative?
+      progress = 100 if progress > 100
+
+      {
+        alias: "Peer #{index.to_s.rjust(2, '0')}",
+        progress: progress,
+        band_label: if progress >= 85
+                      'Leading'
+                    elsif progress >= 75
+                      'On Track'
+                    elsif progress >= 65
+                      'Building'
+                    else
+                      'Needs Support'
+                    end,
+        is_current_student: peer_project.id == project.id
+      }
+    end
+
+    present peers, with: Grape::Presenters::Presenter
+  end
+
   desc 'Update a project'
   params do
     optional :trigger,            type: String,  desc: 'The update trigger'

--- a/test/api/projects_api_test.rb
+++ b/test/api/projects_api_test.rb
@@ -112,6 +112,38 @@ class ProjectsApiTest < ActiveSupport::TestCase
     end
   end
 
+  def test_get_project_peer_progress_response_is_correct
+    unit = FactoryBot.create(:unit)
+    project = unit.active_projects.first
+
+    add_auth_header_for(user: project.student)
+
+    get "/api/projects/#{project.id}/peer_progress"
+    assert_equal 200, last_response.status, last_response_body
+    assert_equal unit.active_projects.count, last_response_body.count
+
+    current_student_entries = last_response_body.select { |entry| entry['is_current_student'] }
+    assert_equal 1, current_student_entries.count
+
+    last_response_body.each_with_index do |entry, index|
+      assert_json_limit_keys_to_exactly %w(alias progress band_label is_current_student), entry
+      assert_equal "Peer #{(index + 1).to_s.rjust(2, '0')}", entry['alias']
+      assert entry['progress'].between?(0, 100), entry.inspect
+      assert %w(Leading On\ Track Building Needs\ Support).include?(entry['band_label']), entry.inspect
+    end
+  end
+
+  def test_get_project_peer_progress_requires_project_access
+    unit = FactoryBot.create(:unit)
+    project = unit.active_projects.first
+    other_user = FactoryBot.create(:user, :student, enrol_in: 1)
+
+    add_auth_header_for(user: other_user)
+
+    get "/api/projects/#{project.id}/peer_progress"
+    assert_equal 403, last_response.status
+  end
+
   def test_submitted_grade_cant_change_after_submission
     user = FactoryBot.create(:user, :student, enrol_in: 1)
     project = user.projects.first


### PR DESCRIPTION
# Description

A new backend endpoint was added to support the Peer Progress feature: GET /api/projects/:id/peer_progress. The implementation is in projects_api.rb (line 41).

This endpoint uses the current project ID to find the student’s project, then uses that project’s unit to retrieve all active projects enrolled in the same unit. That means the peer data is matched through the unit the student belongs to, rather than by manually passing a unit code like COS100001 from the frontend.

The endpoint preserves student privacy by returning anonymized peer records only. Instead of exposing names or personal details, each student is returned as an alias such as Peer 01, Peer 02, and so on. The API also identifies which record belongs to the current student through an is_current_student flag.

Each peer’s progress is calculated from the existing task_stats stored on the project, specifically the order_scale value. That value is converted into a percentage and clamped between 0 and 100. A simple progress band is also assigned for display purposes:

Leading
On Track
Building
Needs Support

The endpoint includes an authorization check before returning data. A user must already have access to the requested project; otherwise the API responds with 403. This keeps the feature aligned with existing project access rules while still allowing real unit-based peer progress to be shown safely.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test: env RAILS_ENV=test bundle exec ruby -Itest test/api/projects_api_test.rb
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

If you have any questions, please contact @macite or @jakerenzella.
