### PR TITLE
feat: clear submission in process with no active sidekiq job

### DIFF
--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -49,7 +49,8 @@ namespace :maintenance do
     in_process_path = FileHelper.student_work_dir(:in_process)
     return unless Dir.exist?(in_process_path)
 
-    stale_before = 10.minutes.ago
+    abandoned_submission_timeout = 10.minutes
+    stale_before = abandoned_submission_timeout.ago
 
     Dir.foreach(in_process_path) do |entry|
       next unless entry.match?(/^\d+$/)
@@ -66,7 +67,7 @@ namespace :maintenance do
         next
       end
 
-      message = "Abandoned in-process submission detected for task #{task.log_details}. The stale in-process folder was older than 5 minutes with no active AcceptSubmissionJob, has now been cleared, and the task requires resubmission."
+      message = "Abandoned in-process submission detected for task #{task.log_details}. The stale in-process folder was older than #{abandoned_submission_timeout / 1.minute} minutes with no active AcceptSubmissionJob, has now been cleared, and the task requires resubmission."
       Rails.logger.error message
 
       mark_task_for_resubmission(task, message)

--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -1,6 +1,80 @@
 require_all 'lib/helpers'
+require 'sidekiq/api'
 
 namespace :maintenance do
+  def accept_submission_job_present?(task_id)
+    Sidekiq::Queue.new("default").each do |job|
+      return true if job.klass == 'AcceptSubmissionJob' && job.args[0] == task_id
+    end
+
+    Sidekiq::Workers.new.each do |_process_id, _thread_id, work|
+      payload = JSON.parse(work['payload'])
+
+      return true if payload['class'] == 'AcceptSubmissionJob' && payload['args'][0] == task_id
+    end
+
+    false
+  end
+
+  def notify_failed_submission(task, message)
+    if task.project.student.receive_task_notifications
+      begin
+        PortfolioEvidenceMailer.task_pdf_failed(task.project, [task]).deliver_now
+      rescue StandardError => e
+        Rails.logger.error "Failed to send task pdf failed email for project #{task.project.id}!\n#{e.message}"
+      end
+    end
+
+    exception = StandardError.new(message)
+    Sentry.capture_exception(exception, extra: { task_id: task.id, project_id: task.project_id }) if defined?(Sentry)
+
+    begin
+      mail = ErrorLogMailer.error_message('Accept Submission Cleanup', message, exception)
+      mail.deliver_now if mail.present?
+    rescue StandardError => e
+      Rails.logger.error "Failed to send error log to admin for task #{task.id}!\n#{e.message}"
+    end
+  end
+
+  def mark_task_for_resubmission(task, _message)
+    tutor = task.project.tutor_for(task.task_definition)
+
+    task.trigger_transition(trigger: 'fix', by_user: tutor)
+    task.add_text_comment(tutor, "**Automated Comment**: Something went wrong with compiling your submission. Please resubmit the task.")
+  rescue StandardError => e
+    Rails.logger.error "Failed to move task #{task.id} to fix and add automated comment!\n#{e.message}"
+  end
+
+  def clear_abandoned_submissions!
+    in_process_path = FileHelper.student_work_dir(:in_process)
+    return unless Dir.exist?(in_process_path)
+
+    stale_before = 10.minutes.ago
+
+    Dir.foreach(in_process_path) do |entry|
+      next unless entry.match?(/^\d+$/)
+
+      task_path = File.join(in_process_path, entry)
+      next unless File.directory?(task_path)
+      next unless File.mtime(task_path) < stale_before
+
+      task = Task.includes(project: [:user, :unit]).find_by(id: entry.to_i)
+      next if task.nil?
+
+      if accept_submission_job_present?(task.id)
+        Rails.logger.info "Skipping abandoned submission cleanup for task #{task.id} because AcceptSubmissionJob is still active"
+        next
+      end
+
+      message = "Abandoned in-process submission detected for task #{task.log_details}. The stale in-process folder was older than 5 minutes with no active AcceptSubmissionJob, has now been cleared, and the task requires resubmission."
+      Rails.logger.error message
+
+      mark_task_for_resubmission(task, message)
+      task.clear_in_process
+      notify_failed_submission(task, message)
+    end
+  end
+
   desc 'Cleanup temporary files'
   task cleanup: [:environment] do
     path = FileHelper.tmp_file_dir
@@ -31,6 +105,12 @@ namespace :maintenance do
       .find_each(&:destroy!)
 
     AuthToken.destroy_old_tokens
+    clear_abandoned_submissions!
+  end
+
+  desc 'Clear abandoned in-process submission folders and notify affected users'
+  task clear_abandoned_submissions: [:environment] do
+    clear_abandoned_submissions!
   end
 
   desc 'Remove PDFs from old submissions and archive units'


### PR DESCRIPTION
this should catch edge cases where the api's host is shutdown/restarted in the middle of an AcceptSubmissionJob - ideally we ensure the sidekiq queue is paused prior but we still need to handle stale in_process jobs and notify the student

during the maintenance rake task (which is run every 5 minutes)..
- search for tasks in the `in_process` directory
- check if its older than 10 minutes (no submission has ever taken more than 10 minutes to compile right?)
- ensure theres no active AcceptSubmissionJob for that task
- remove the task from `in_process`
- move the task to fix, and email the student asking them to resubmit
- submit a sentry error log

we could attempt to re-run convert_submission_to_pdf but dont want to risk it looping in case something else is breaking it

TODO: do we need this for overseer jobs too?