### PR TITLE
feat: notify students when overseer tests fail

### DIFF
--- a/.ci-setup/crontab
+++ b/.ci-setup/crontab
@@ -3,6 +3,7 @@ BASH_ENV=/container.env
 PATH=/tmp/texlive/bin/x86_64-linux:/tmp/texlive/bin/aarch64-linux:/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bundle/bin
 
 10,15,20,25,30,35,40,45,50,55 * * * * /doubtfire/lib/shell/generate_pdfs.sh
+0,10,20,30,40,50 * * * * /doubtfire/lib/shell/send_overseer_notifications.sh
 0 5 * * * /doubtfire/lib/shell/check_plagiarism.sh
 0 8 * * * /doubtfire/lib/shell/portfolio_autogen_check.sh
 0 7 * * 1 /doubtfire/lib/shell/send_weekly_emails.sh

--- a/app/mailers/portfolio_evidence_mailer.rb
+++ b/app/mailers/portfolio_evidence_mailer.rb
@@ -54,6 +54,22 @@ class PortfolioEvidenceMailer < ApplicationMailer
     mail(to: email_with_name, from: tutor_email, subject: subject)
   end
 
+  def overseer_assessment_failed(project, tasks)
+    return nil if project.nil? || tasks.nil? || tasks.empty?
+
+    add_general
+    @student = project.student
+    @project = project
+    @tasks = tasks.sort_by { |t| t.task_definition.abbreviation }
+    @tutor = project.main_convenor_user
+    return nil if @tutor.nil? || @student.nil?
+
+    email_with_name = %("#{@student.name}" <#{@student.email}>)
+    tutor_email = %("#{@tutor.name}" <#{@tutor.email}>)
+    subject = "#{project.unit.code} #{project.unit.name}: Automated feedback needs your attention"
+    mail(to: email_with_name, from: tutor_email, subject: subject)
+  end
+
   def portfolio_ready(project)
     return nil if project.nil?
 

--- a/app/models/overseer_assessment.rb
+++ b/app/models/overseer_assessment.rb
@@ -1,7 +1,5 @@
 # rubocop:disable Rails/Output
 class OverseerAssessment < ApplicationRecord
-  STUDENT_NOTIFICATION_GRACE_PERIOD = 30.minutes
-
   belongs_to :task, optional: false
 
   has_one :project, through: :task
@@ -20,7 +18,11 @@ class OverseerAssessment < ApplicationRecord
 
 
 
-  scope :awaiting_student_failure_notification, lambda { |grace_period: STUDENT_NOTIFICATION_GRACE_PERIOD|
+  def self.student_notification_grace_period
+    Doubtfire::Application.config.overseer_student_notification_grace_period
+  end
+
+  scope :awaiting_student_failure_notification, lambda { |grace_period: student_notification_grace_period|
     notification_cutoff = grace_period.ago
 
     joins(task: { project: :user })

--- a/app/models/overseer_assessment.rb
+++ b/app/models/overseer_assessment.rb
@@ -1,5 +1,7 @@
 # rubocop:disable Rails/Output
 class OverseerAssessment < ApplicationRecord
+  STUDENT_NOTIFICATION_GRACE_PERIOD = 30.minutes
+
   belongs_to :task, optional: false
 
   has_one :project, through: :task
@@ -15,6 +17,54 @@ class OverseerAssessment < ApplicationRecord
   enum :status, { pre_queued: 0, passed: 1, failed: 2 }
 
   after_destroy :delete_associated_files
+
+
+
+  scope :awaiting_student_failure_notification, lambda { |grace_period: STUDENT_NOTIFICATION_GRACE_PERIOD|
+    notification_cutoff = grace_period.ago
+
+    joins(task: { project: :user })
+      .joins(<<~SQL.squish)
+        INNER JOIN task_comments assessment_comments
+          ON assessment_comments.commentable_type = 'OverseerAssessment'
+         AND assessment_comments.commentable_id = overseer_assessments.id
+         AND assessment_comments.type = 'AssessmentComment'
+      SQL
+      .joins(<<~SQL.squish)
+        LEFT JOIN comments_read_receipts student_read_receipts
+          ON student_read_receipts.task_comment_id = assessment_comments.id
+         AND student_read_receipts.user_id = projects.user_id
+      SQL
+      .where(status: statuses[:failed], student_notified_at: nil)
+      .where(users: { receive_task_notifications: true })
+      .where('overseer_assessments.updated_at <= ?', notification_cutoff)
+      .where('student_read_receipts.id IS NULL')
+      .where(<<~SQL.squish)
+        assessment_comments.id = (
+          SELECT latest_comment.id
+          FROM task_comments latest_comment
+          WHERE latest_comment.commentable_type = 'OverseerAssessment'
+            AND latest_comment.commentable_id = overseer_assessments.id
+            AND latest_comment.type = 'AssessmentComment'
+          ORDER BY latest_comment.created_at DESC, latest_comment.id DESC
+          LIMIT 1
+        )
+      SQL
+      .where(<<~SQL.squish)
+        NOT EXISTS (
+          SELECT 1
+          FROM overseer_assessments newer_assessments
+          WHERE newer_assessments.task_id = overseer_assessments.task_id
+            AND (
+              newer_assessments.created_at > overseer_assessments.created_at OR
+              (
+                newer_assessments.created_at = overseer_assessments.created_at AND
+                newer_assessments.id > overseer_assessments.id
+              )
+            )
+        )
+      SQL
+  }
 
   # TODO: track how many tests ran, and how many tests total at the time
   # TODO: we might not have an overseerStepResult because a new test was added later
@@ -84,6 +134,10 @@ class OverseerAssessment < ApplicationRecord
   # Path to where the submission and output are stored - includes the submission when it is to be processed
   def output_path
     FileHelper.task_submission_identifier_path_with_timestamp(:done, task, submission_timestamp)
+  end
+
+  def latest_assessment_comment
+    assessment_comments.order(created_at: :desc, id: :desc).first
   end
 
   def add_assessment_comment(text = 'Automated Assessment Started')

--- a/app/views/portfolio_evidence_mailer/overseer_assessment_failed.html.erb
+++ b/app/views/portfolio_evidence_mailer/overseer_assessment_failed.html.erb
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style type="text/css">
+    .main {
+      font-family: "Lucida Grande", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      color: #333;
+      font-size: 14px;
+      width: 100%;
+      max-width: 800px;
+      margin: 100px auto 0px auto;
+      background-image: url('<%= @doubtfire_host %>/assets/images/logo.png');
+      background-size: 3.5em;
+      background-repeat: no-repeat;
+      background-position: top 40px right 45px;
+      padding: 30px 40px;
+      border: solid 1px rgb(240, 240, 240);
+      line-height: 200%;
+      text-align: justify;
+    }
+    footer, .footer {
+      font-family: "Lucida Grande", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      text-align: center;
+      margin-top: 10px;
+      color: #aaa;
+      font-size: 0.7em;
+    }
+    a, a:visited {
+      color: #6a97d2;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    ul {
+      list-style: none;
+    }
+    h1 {
+      font-size: 1.1em;
+    }
+  </style>
+</head>
+<body>
+  <div class="main">
+    <h1> <%= @doubtfire_product_name %> Notification </h1>
+    <p>Hi <%= @student.first_name %>,</p>
+    <p>
+      Our automated assessment found issues and left feedback on the following tasks. If you have already reviewed the task in <%= @doubtfire_product_name %>, you can ignore this email.
+    </p>
+    <p>
+      Please log in and review the latest automated feedback for:
+      <ul>
+        <% @tasks.each do |task| %>
+          <li>
+            <strong><%= task.task_definition.abbreviation %> - </strong>
+            <a href="<%= @doubtfire_host %>/#/projects/<%= @project.id %>/dashboard/<%= task.task_definition.abbreviation %>">
+              <%= task.task_definition.name %>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </p>
+    <p>
+      Cheers, <br />
+      The <%= @doubtfire_product_name %> Team on behalf of <%= @tutor.name %>
+    </p>
+  </div>
+  <footer class="footer">
+    <a href="<%= @unsubscribe_url %>">Unsubscribe</a> | Generated with <%= @doubtfire_product_name %>
+  </footer>
+</body>
+</html>

--- a/app/views/portfolio_evidence_mailer/overseer_assessment_failed.text.erb
+++ b/app/views/portfolio_evidence_mailer/overseer_assessment_failed.text.erb
@@ -1,0 +1,17 @@
+Hi <%= @student.first_name %>,
+
+Our automated assessment found issues and left feedback on the following tasks. If you have already reviewed the task in <%= @doubtfire_product_name %>, you can ignore this email.
+
+Please log in and review the latest automated feedback for:
+<% @tasks.each do |task| %>
+  * <%= task.task_definition.abbreviation %> - <%= task.task_definition.name %>
+<% end %>
+
+Cheers,
+The <%= @doubtfire_product_name %> Team on behalf of <%= @tutor.name %>
+
+---
+
+Visit <%= @unsubscribe_url %> to unsubscribe from these notifications.
+
+Generated with <%= @doubtfire_product_name %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,9 @@ module Doubtfire
     # Period for which to keep units
     config.unit_archive_after_period = ENV.fetch('DF_UNIT_ARCHIVE_PERIOD', 2).to_f * 1.year
 
+    # Minimum time to wait before notifying a student about an unread failed overseer assessment
+    config.overseer_student_notification_grace_period = ENV.fetch('OVERSEER_STUDENT_NOTIFICATION_GRACE_PERIOD_MINUTES', 30).to_i.minutes
+
     # Limit number of pdf generators to run at once
     config.pdfgen_max_processes = ENV['DF_MAX_PDF_GEN_PROCESSES'] || 2
 

--- a/db/migrate/20260604031804_add_student_notified_at_to_overseer_assessments.rb
+++ b/db/migrate/20260604031804_add_student_notified_at_to_overseer_assessments.rb
@@ -1,0 +1,7 @@
+class AddStudentNotifiedAtToOverseerAssessments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :overseer_assessments, :student_notified_at, :datetime
+    add_index :overseer_assessments, [:status, :student_notified_at, :updated_at],
+              name: 'index_overseer_assessments_on_status_notified_updated'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_27_041457) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_04_031804) do
   create_table "activity_types", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation", null: false
@@ -242,6 +242,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_27_041457) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "total_steps"
+    t.datetime "student_notified_at"
+    t.index ["status", "student_notified_at", "updated_at"], name: "index_overseer_assessments_on_status_notified_updated"
     t.index ["task_id", "submission_timestamp"], name: "index_overseer_assessments_on_task_id_and_submission_timestamp", unique: true
     t.index ["task_id"], name: "index_overseer_assessments_on_task_id"
   end

--- a/lib/shell/send_overseer_notifications.sh
+++ b/lib/shell/send_overseer_notifications.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#Get path to script
+APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
+APP_PATH=`cd "$APP_PATH"; pwd`
+
+ROOT_PATH=`cd "$APP_PATH"/../..; pwd`
+
+cd "$ROOT_PATH"
+
+DF_LOG_TO_STDOUT=true rails overseer_notifications:send_failed_assessment_notifications

--- a/lib/tasks/overseer_notifications.rake
+++ b/lib/tasks/overseer_notifications.rake
@@ -1,0 +1,26 @@
+namespace :overseer_notifications do
+  def notify_failed_overseer_assessments!
+    assessments = OverseerAssessment
+                  .awaiting_student_failure_notification
+                  .includes(task: [{ project: :unit }, :task_definition])
+
+    assessments.group_by(&:project).each do |project, project_assessments|
+      tasks = project_assessments.map(&:task).uniq
+
+      begin
+        mail = PortfolioEvidenceMailer.overseer_assessment_failed(project, tasks)
+        next if mail.blank?
+
+        mail.deliver_now
+        OverseerAssessment.where(id: project_assessments.map(&:id)).update_all(student_notified_at: Time.current)
+      rescue StandardError => e
+        Rails.logger.error "Failed to send overseer assessment email for project #{project.id}!\n#{e.message}"
+      end
+    end
+  end
+
+  desc 'Send overdue overseer assessment failure notifications to students'
+  task send_failed_assessment_notifications: [:environment] do
+    notify_failed_overseer_assessments!
+  end
+end

--- a/lib/tasks/overseer_notifications.rake
+++ b/lib/tasks/overseer_notifications.rake
@@ -12,7 +12,9 @@ namespace :overseer_notifications do
         next if mail.blank?
 
         mail.deliver_now
-        OverseerAssessment.where(id: project_assessments.map(&:id)).update_all(student_notified_at: Time.current)
+        project_assessments.each do |assessment|
+          assessment.update!(student_notified_at: Time.current)
+        end
       rescue StandardError => e
         Rails.logger.error "Failed to send overseer assessment email for project #{project.id}!\n#{e.message}"
       end

--- a/test/mailers/unit_mail_test.rb
+++ b/test/mailers/unit_mail_test.rb
@@ -54,4 +54,23 @@ class UnitMailTest < ActionMailer::TestCase
     unit.destroy!
   end
 
+  def test_send_overseer_assessment_failed_email
+    unit = FactoryBot.create :unit
+    convenor = FactoryBot.create :user, :convenor
+
+    ur = unit.employ_staff convenor, Role.convenor
+
+    unit.update main_convenor: ur
+
+    project = unit.active_projects.first
+    task = project.tasks.first
+
+    mail = PortfolioEvidenceMailer.overseer_assessment_failed(project, [task])
+
+    assert_equal 1, mail.from.count
+    assert_equal convenor.email, mail.from.first
+    assert_equal project.student.email, mail.to.first
+    assert mail.html_part.body.include? "projects/#{project.id}/dashboard/#{task.task_definition.abbreviation}"
+  end
+
 end

--- a/test/mailers/unit_mail_test.rb
+++ b/test/mailers/unit_mail_test.rb
@@ -63,7 +63,7 @@ class UnitMailTest < ActionMailer::TestCase
     unit.update main_convenor: ur
 
     project = unit.active_projects.first
-    task = project.tasks.first
+    task = project.task_for_task_definition(unit.task_definitions.first)
 
     mail = PortfolioEvidenceMailer.overseer_assessment_failed(project, [task])
 

--- a/test/models/overseer_assessment_test.rb
+++ b/test/models/overseer_assessment_test.rb
@@ -54,7 +54,10 @@ class OverseerAssessmentTest < ActiveSupport::TestCase
 
   def create_assessment(status:, age:, task: nil, create_comment: false)
     unit = FactoryBot.create(:unit, task_count: 1) if task.nil?
-    task ||= unit.active_projects.first.tasks.first
+    task ||= begin
+      project = unit.active_projects.first
+      project.task_for_task_definition(unit.task_definitions.first)
+    end
 
     assessment = OverseerAssessment.create!(
       task: task,

--- a/test/models/overseer_assessment_test.rb
+++ b/test/models/overseer_assessment_test.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+
+class OverseerAssessmentTest < ActiveSupport::TestCase
+  def test_selects_latest_failed_unread_assessment_once_grace_period_has_elapsed
+    assessment = create_failed_assessment
+
+    pending_ids = OverseerAssessment.awaiting_student_failure_notification.pluck(:id)
+
+    assert_includes pending_ids, assessment.id
+  end
+
+  def test_excludes_assessment_when_student_has_read_comment
+    assessment = create_failed_assessment
+    assessment.latest_assessment_comment.mark_as_read(assessment.project.student)
+
+    pending_ids = OverseerAssessment.awaiting_student_failure_notification.pluck(:id)
+
+    assert_not_includes pending_ids, assessment.id
+  end
+
+  def test_excludes_older_failed_assessment_when_a_newer_assessment_exists
+    older_failed = create_failed_assessment
+    create_assessment(task: older_failed.task, status: :passed, age: 20.minutes)
+
+    pending_ids = OverseerAssessment.awaiting_student_failure_notification.pluck(:id)
+
+    assert_not_includes pending_ids, older_failed.id
+  end
+
+  def test_only_selects_latest_failed_assessment_for_a_task
+    older_failed = create_failed_assessment
+    newer_failed = create_failed_assessment(task: older_failed.task, age: 35.minutes)
+
+    pending_ids = OverseerAssessment.awaiting_student_failure_notification.pluck(:id)
+
+    assert_not_includes pending_ids, older_failed.id
+    assert_includes pending_ids, newer_failed.id
+  end
+
+  def test_excludes_already_notified_assessment
+    assessment = create_failed_assessment
+    assessment.update_column(:student_notified_at, Time.current)
+
+    pending_ids = OverseerAssessment.awaiting_student_failure_notification.pluck(:id)
+
+    assert_not_includes pending_ids, assessment.id
+  end
+
+  private
+
+  def create_failed_assessment(task: nil, age: 40.minutes)
+    create_assessment(task: task, status: :failed, age: age, create_comment: true)
+  end
+
+  def create_assessment(status:, age:, task: nil, create_comment: false)
+    unit = FactoryBot.create(:unit, task_count: 1) if task.nil?
+    task ||= unit.active_projects.first.tasks.first
+
+    assessment = OverseerAssessment.create!(
+      task: task,
+      status: status,
+      submission_timestamp: "#{Time.current.to_i}-#{SecureRandom.hex(2)}"
+    )
+    assessment.update_columns(created_at: age.ago, updated_at: age.ago)
+
+    if create_comment
+      comment = AssessmentComment.create!(
+        task: task,
+        user: task.project.tutor_for(task.task_definition),
+        recipient: task.project.student,
+        comment: 'Automated tests failed',
+        commentable: assessment
+      )
+      comment.update_columns(created_at: age.ago)
+    end
+
+    assessment
+  end
+end


### PR DESCRIPTION
- If a student hasn't viewed their task (opened the comments) containing a failed overseer test, then they'll get an email notifying them about the test
- So this allows students to submit and view overseer results hundreds of times without getting notifications unless they have actually stepped away and are not actively checking task's feedback
