### PR TITLE
refactor: reset portfolio compilation after completion

### DIFF
--- a/app/models/pdf_generation/project_compile_portfolio_module.rb
+++ b/app/models/pdf_generation/project_compile_portfolio_module.rb
@@ -113,6 +113,7 @@ module PdfGeneration
 
     # Create the portfolio for this project
     def create_portfolio
+      logger.info "Creating portfolio for #{user.username} in #{unit.code}"
       begin
         pac = ProjectAppController.new
         pac.init(self, false)

--- a/app/models/pdf_generation/project_compile_portfolio_module.rb
+++ b/app/models/pdf_generation/project_compile_portfolio_module.rb
@@ -113,9 +113,6 @@ module PdfGeneration
 
     # Create the portfolio for this project
     def create_portfolio
-      self.compile_portfolio = false
-      save!
-
       begin
         pac = ProjectAppController.new
         pac.init(self, false)
@@ -142,8 +139,13 @@ module PdfGeneration
         logger.info "Created portfolio at #{portfolio_path} - #{log_details}"
 
         self.portfolio_production_date = Time.zone.now
-        save
+        self.compile_portfolio = false
+        save!
+        true
       rescue StandardError => e
+        self.compile_portfolio = false
+        save!
+
         logger.error "Failed to convert portfolio to PDF - #{log_details} -\nError: #{e.message}"
 
         log_file = e.message.scan(%r{/.*\.log}).first


### PR DESCRIPTION
- avoids edge cases where a portfolio begins compiling but a student is prompted with the "Create my portfolio" ui before the pdf gen completes, so the students who are constantly refreshing the portfolio page will then re-queue their portfolio compilation, they then receive an email saying their portfolio is complete, but then refresh to see that their portfolio is still compiling
