### PR TITLE
feat: store aggregated task status to serve immediately

### DIFF
--- a/app/api/units_api.rb
+++ b/app/api/units_api.rb
@@ -659,26 +659,19 @@ class UnitsApi < Grape::API
       error!({ error: "Not authorised to download stats of student tasks in #{unit.code}" }, 403)
     end
 
-    snapshots = unit.task_completion_snapshots.order(snapshot_timestamp: :desc)
+    # Already aggregated and ordered newest first, so this only has to filter.
+    snapshots = unit.task_completion_snapshot_stats
     if params[:start_date].present?
       start_timestamp = params[:start_date].in_time_zone.beginning_of_day.to_i
-      snapshots = snapshots.where('CAST(snapshot_timestamp AS UNSIGNED) >= ?', start_timestamp)
+      snapshots = snapshots.select { |snapshot| snapshot['snapshot_timestamp'].to_i >= start_timestamp }
     end
     if params[:end_date].present?
       end_timestamp = params[:end_date].in_time_zone.end_of_day.to_i
-      snapshots = snapshots.where('CAST(snapshot_timestamp AS UNSIGNED) <= ?', end_timestamp)
+      snapshots = snapshots.select { |snapshot| snapshot['snapshot_timestamp'].to_i <= end_timestamp }
     end
-    snapshots = snapshots.limit([params[:limit].to_i, 365].min)
+    snapshots = snapshots.first([params[:limit].to_i, 365].min)
 
-    present snapshots.map { |snapshot|
-      stats = snapshot.load_stats
-
-      {
-        snapshot_date: snapshot.snapshot_date,
-        snapshot_timestamp: snapshot.snapshot_timestamp,
-        stats: stats
-      }
-    }, with: Grape::Presenters::Presenter
+    present snapshots, with: Grape::Presenters::Presenter
   end
 
   desc 'Capture task completion snapshot immediately for this unit'

--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -464,6 +464,15 @@ module FileHelper
     File.join(analytics_dir, 'task-status-snapshots.zip')
   end
 
+  # Aggregated stats for every snapshot, kept beside the zip so the analytics endpoint never
+  # has to parse the CSVs. Disposable - it is rebuilt from the zip whenever it goes stale.
+  # Gzipped because the stats repeat the same status keys per task, per tutorial, per campus.
+  def unit_task_status_snapshot_stats_path(unit, create: true, archived: true)
+    analytics_dir = unit_analytics_dir(unit, create: create, archived: archived)
+    FileUtils.mkdir_p(analytics_dir) if create
+    File.join(analytics_dir, 'task-status-snapshots.json.gz')
+  end
+
   def snapshot_csv_filename(snapshot_timestamp)
     return nil if snapshot_timestamp.blank?
     "#{sanitized_filename(snapshot_timestamp.to_s)}.csv"
@@ -1193,6 +1202,7 @@ module FileHelper
   module_function :unit_portfolio_dir
   module_function :unit_analytics_dir
   module_function :unit_task_status_snapshot_path
+  module_function :unit_task_status_snapshot_stats_path
   module_function :snapshot_csv_filename
   module_function :unit_work_root
   module_function :project_work_root

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -3986,7 +3986,60 @@ class Unit < ApplicationRecord
       .tap do |snapshot|
       snapshot.save!
       snapshot.store_stats!(snapshot_payload)
+      refresh_task_completion_snapshot_stats!(snapshot)
     end
+  end
+
+  # Stats for every snapshot, read from the aggregated file so no CSV is parsed per request.
+  # Rebuilt only when that file is missing, unreadable, or no longer matches the snapshots on record.
+  def task_completion_snapshot_stats
+    path = FileHelper.unit_task_status_snapshot_stats_path(self, create: false)
+    cached = File.exist?(path) ? JSON.parse(Zlib::GzipReader.open(path, &:read)) : nil
+
+    if cached.present? &&
+       cached.map { |entry| entry['snapshot_timestamp'] }.sort == TaskCompletionSnapshot.where(unit_id: id).pluck(:snapshot_timestamp).sort
+      return cached
+    end
+
+    refresh_task_completion_snapshot_stats!
+  rescue JSON::ParserError, Zlib::Error
+    refresh_task_completion_snapshot_stats!
+  end
+
+  # Writes the aggregated file. Stats for an already captured snapshot never change, so passing the
+  # snapshot that just changed merges it in rather than re-parsing every other CSV.
+  def refresh_task_completion_snapshot_stats!(changed_snapshot = nil)
+    path = FileHelper.unit_task_status_snapshot_stats_path(self, create: true)
+
+    entries =
+      if changed_snapshot.present? && File.exist?(path)
+        JSON.parse(Zlib::GzipReader.open(path, &:read)).reject { |entry| entry['snapshot_timestamp'] == changed_snapshot.snapshot_timestamp } +
+          [{
+            'snapshot_date' => changed_snapshot.snapshot_date&.iso8601,
+            'snapshot_timestamp' => changed_snapshot.snapshot_timestamp,
+            'stats' => changed_snapshot.load_stats
+          }]
+      else
+        task_completion_snapshots.reload.map do |snapshot|
+          {
+            'snapshot_date' => snapshot.snapshot_date&.iso8601,
+            'snapshot_timestamp' => snapshot.snapshot_timestamp,
+            'stats' => snapshot.load_stats
+          }
+        end
+      end
+
+    entries = entries.sort_by { |entry| -entry['snapshot_timestamp'].to_i }
+
+    tmp_path = "#{path}.tmp"
+    Zlib::GzipWriter.open(tmp_path) { |gz| gz.write(JSON.generate(entries)) }
+    FileUtils.mv(tmp_path, path)
+
+    entries
+  rescue JSON::ParserError, Zlib::Error
+    # An unreadable file cannot be merged into; drop it so the retry does a full rebuild.
+    FileUtils.rm_f(path)
+    refresh_task_completion_snapshot_stats!
   end
 
   private


### PR DESCRIPTION
- Instead of parsing and aggregating the data on every fetch we build the json after capturing the task completion csv snapshots
- We retain the csv's for historical data, we can use these for other graphs
- But we only need to aggregate the data once then we can serve the json immediately